### PR TITLE
feat: add swap role and enable for all hosts

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -17,6 +17,7 @@
   roles:
     - role: aws
       when: is_aws_environment
+    - swap
 
 # Setup VPN
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -106,3 +106,6 @@ masternode_wallet_rpc_port: '{{ dashd_rpc_port }}'
 masternode_wallet_rpc_user: '{{ dashd_rpc_user }}'
 masternode_wallet_rpc_password: '{{ dashd_rpc_password }}'
 masternode_wallet_rpc_args: '-rpcconnect={{ masternode_wallet_rpc_host }} -rpcport={{ masternode_wallet_rpc_port }} -rpcuser={{ masternode_wallet_rpc_user }} -rpcpassword={{ masternode_wallet_rpc_password }}'
+
+# Disk space allocated for swap file on each host
+swap_space: 2G

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: set swap_file variable
+  set_fact:
+    swap_file: /swapfile
+
+- name: check if swap file exists
+  stat:
+    path: "{{ swap_file }}"
+  register: swap_file_check
+
+- name: create swap file
+  become: yes
+  become_user: root
+  command: fallocate -l {{ swap_space }} {{ swap_file }}
+  when: not swap_file_check.stat.exists
+
+- name: set permissions on swap file
+  become: yes
+  become_user: root
+  file:
+    path: "{{ swap_file }}"
+    mode: 0600
+
+- name: format swap file
+  become: yes
+  become_user: root
+  command: mkswap {{ swap_file }}
+  when: not swap_file_check.stat.exists
+
+- name: add to fstab
+  become: yes
+  become_user: root
+  lineinfile:
+    dest: /etc/fstab
+    regexp: "{{ swap_file }}"
+    line: "{{ swap_file }} none swap sw 0 0"
+
+- name: turn on swap
+  become: yes
+  become_user: root
+  command: swapon -a
+
+- name: set swapiness
+  become: yes
+  become_user: root
+  sysctl:
+    name: vm.swappiness
+    value: "60"


### PR DESCRIPTION
Currently we are getting processes killed due to Out-of-Memory (OOM). Adding a swap file is standard to prevent this and can be used as a quick fix for OOM issues as well as to monitor for actual memory requirements (RAM) in case we want to bump those and provide a recommendation.