### PR TITLE
fix: some DNS services block long records

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -161,8 +161,8 @@ locals {
 }
 
 resource "random_shuffle" "dns_ips" {
-  input = concat(aws_instance.masternode.*.public_ip)
-  result_count = length(concat(aws_instance.masternode.*.public_ip)) > local.dns_record_length ? local.dns_record_length : length(concat(aws_instance.masternode.*.public_ip)) 
+  input        = concat(aws_instance.masternode.*.public_ip)
+  result_count = length(concat(aws_instance.masternode.*.public_ip)) > local.dns_record_length ? local.dns_record_length : length(concat(aws_instance.masternode.*.public_ip))
 }
 
 resource "aws_route53_record" "masternodes" {
@@ -170,7 +170,7 @@ resource "aws_route53_record" "masternodes" {
   name    = "seed-${count.index + 1}.${var.public_network_name}.${var.main_domain}"
   type    = "A"
   ttl     = "300"
-  records = [ random_shuffle.dns_ips.result ]
+  records = random_shuffle.dns_ips.result
 
   count = length(var.main_domain) > 1 ? 5 : 0
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some of DNS services block records longer than 10 IPs

## What was done?
<!--- Describe your changes in detail -->
We add only 10 IPs to each DNS record.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With Terraform plan and with manually created DNS record with 10 IPs.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone