### PR TITLE
fix: use v3 AWS provider syntax

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 data "aws_availability_zones" "available" {
-  blacklisted_names = ["us-west-2d"]
-  state             = "available"
+  exclude_names = ["us-west-2d"]
+  state         = "available"
 }
 
 data "aws_ami" "ubuntu" {


### PR DESCRIPTION
Updates provider syntax to v3

## Issue being fixed or feature implemented
`terraform apply` fails with:
```
Error: Unsupported argument

  on main.tf line 11, in data "aws_availability_zones" "available":
  11:   blacklisted_names = ["us-west-2d"]

An argument named "blacklisted_names" is not expected here.
```


## What was done?
Update provider syntax as described here:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#data-source-aws_availability_zones

## How Has This Been Tested?
Ran `dash-network deploy -i testnet`, no errors.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
