### PR TITLE
feat: move env file to separate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Dash Core developers to assist in Dash Evolution development.
 
 ## Configuration
 
+### Generate .env file
+
+Infrastructure credentials are required for most operations. These are stored in an `.env` file.
+You can use the `envfile` command to generate a blank `.env` file for use as a template.
+
+```bash
+dash-network envfile
+```
+
 ### Networks definition
 
 You can use `generate` command in order to create configs for your network:

--- a/bin/dash-network
+++ b/bin/dash-network
@@ -12,11 +12,12 @@ fi
 # Load configuration
 
 if [[ ! -f ".env" ]]; then
-    echo "Configuration .env file not found
+    if [[ $1 != "envfile" ]]; then
+        echo "Configuration '.env' file not found
 
-Please create and configure '.env' file."
-
-    exit 1;
+Please run 'dash-network envfile' to create a blank '.env' file."
+        exit 1;
+    fi
 else
     source ".env"
 fi
@@ -34,6 +35,7 @@ Commands:
   test      - Run smoke test against specific network
   list      - List network hosts and services
   dash-cli  - Execute DashCore RPC command
+  envfile   - Generate blank '.env' file
   generate  - Generate configs
   logs      - Show specific network service logs"
   exit 0;

--- a/bin/envfile
+++ b/bin/envfile
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -ea
+
+CMD_USAGE="Generate blank '.env' file
+
+Usage: envfile"
+
+for i in "$@"
+do
+case ${i} in
+    -h|--help)
+        echo "$CMD_USAGE"
+        exit 0
+    ;;
+esac
+done
+
+cat > ./networks/.env<< EOF
+# Terraform remote backend configuration https://www.terraform.io/docs/backends/types/s3.html
+TERRAFORM_S3_BUCKET=""
+TERRAFORM_S3_KEY=""
+TERRAFORM_DYNAMODB_TABLE=""
+
+# Absolute paths to private and public keys for SSH access to an infrastructure
+PRIVATE_KEY_PATH=""
+PUBLIC_KEY_PATH=""
+
+# AWS credentials are used by Terraform for creating
+# infrastructure and by Ansible for fetching images from AWS ECR.
+#
+# You should specify credentials for both
+# Ansible and Terraform or specify a particular
+# configuration using "TERRAFORM_" and "ANSIBLE_" prefixes
+
+# AWS_PROFILE="" # You can use AWS_PROFILE instead of AWS credentials
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""
+AWS_REGION=""
+
+# TERRAFORM_AWS_PROFILE=""
+# TERRAFORM_AWS_ACCESS_KEY_ID=""
+# TERRAFORM_AWS_SECRET_ACCESS_KEY=""
+# TERRAFORM_AWS_REGION=""
+
+# ANSIBLE_AWS_PROFILE=""
+# ANSIBLE_AWS_ACCESS_KEY_ID=""
+# ANSIBLE_AWS_SECRET_ACCESS_KEY=""
+# ANSIBLE_AWS_REGION=""
+
+EOF

--- a/bin/generate-configs.js
+++ b/bin/generate-configs.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 
-const fs = require('fs');
-
 const generateAnsibleConfig = require('../lib/configGenerator/generateAnsibleConfig');
 const generateTerraformConfig = require('../lib/configGenerator/generateTerraformConfig');
 
@@ -10,39 +8,6 @@ async function main() {
 
   await generateAnsibleConfig(network, networkName, masternodesCount);
   await generateTerraformConfig(network, networkName, masternodesCount);
-
-  const env = '# Terraform remote backend configuration https://www.terraform.io/docs/backends/types/s3.html\n'
-    + 'TERRAFORM_S3_BUCKET=""\n'
-    + 'TERRAFORM_S3_KEY=""\n'
-    + 'TERRAFORM_DYNAMODB_TABLE=""\n'
-    + '\n'
-    + '# Absolute paths to private and public keys for SSH access to an infrastructure\n'
-    + 'PRIVATE_KEY_PATH=""\n'
-    + 'PUBLIC_KEY_PATH=""\n'
-    + '\n'
-    + '# AWS credentials are used by Terraform for creating\n'
-    + '# infrastructure and by Ansible for fetching images from AWS ECR.\n'
-    + '#\n'
-    + '# You should specify credentials for both\n'
-    + '# Ansible and Terraform or specify a particular\n'
-    + '# configuration using "TERRAFORM_" and "ANSIBLE_" prefixes\n'
-    + '\n'
-    + '# AWS_PROFILE="" # You can use AWS_PROFILE instead of AWS credentials\n'
-    + 'AWS_ACCESS_KEY_ID=""\n'
-    + 'AWS_SECRET_ACCESS_KEY=""\n'
-    + 'AWS_REGION=""\n'
-    + '\n'
-    + '# TERRAFORM_AWS_PROFILE=""\n'
-    + '# TERRAFORM_AWS_ACCESS_KEY_ID=""\n'
-    + '# TERRAFORM_AWS_SECRET_ACCESS_KEY=""\n'
-    + '# TERRAFORM_AWS_REGION=""\n'
-    + '\n'
-    + '# ANSIBLE_AWS_PROFILE=""\n'
-    + '# ANSIBLE_AWS_ACCESS_KEY_ID=""\n'
-    + '# ANSIBLE_AWS_SECRET_ACCESS_KEY=""\n'
-    + '# ANSIBLE_AWS_REGION=""\n';
-
-  fs.writeFileSync('networks/.env', env);
 }
 
 main().catch(console.error);

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-scripts=("deploy destroy test list logs dash-cli generate")
+scripts=("deploy destroy test list logs dash-cli envfile generate")
 
 if [[ " ${scripts[@]} " =~ " ${1} " ]]; then
     script=$1


### PR DESCRIPTION
Add `envfile` command

## Issue being fixed or feature implemented
The `generate` command previously generated a new `.env` file every time, overwriting existing envs.


## What was done?
Added `envfile` command and removed envfile generation from `generate` command.


## How Has This Been Tested?
Tested with locally built image.

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
