### PR TITLE
feat: validate .env in init

### DIFF
--- a/bin/dash-network
+++ b/bin/dash-network
@@ -9,6 +9,12 @@ if ! [[ -x "$(command -v docker)" ]]; then
   exit 1
 fi
 
+# Load configuration	
+
+if [[ -f ".env" ]]; then
+    source ".env"
+fi
+
 # Show help if command is not specified
 
 if [[ -z $1 ]]; then

--- a/bin/dash-network
+++ b/bin/dash-network
@@ -9,18 +9,6 @@ if ! [[ -x "$(command -v docker)" ]]; then
   exit 1
 fi
 
-# Load configuration
-
-if [[ ! -f ".env" ]]; then
-    echo "Configuration .env file not found
-
-Please create and configure '.env' file."
-
-    exit 1;
-else
-    source ".env"
-fi
-
 # Show help if command is not specified
 
 if [[ -z $1 ]]; then

--- a/bin/generate
+++ b/bin/generate
@@ -21,6 +21,10 @@ done
 NETWORK_NAME="$1"
 MASTERNODES_COUNT="$2"
 
+if [[ -z ${NETWORK_NAME} ]]; then
+    print_error "Network name is required"
+fi
+
 if [[ -z ${MASTERNODES_COUNT} ]]; then
     print_error "Masternodes count is required"
 fi

--- a/bin/generate-configs.js
+++ b/bin/generate-configs.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 
-const fs = require('fs');
-
 const generateAnsibleConfig = require('../lib/configGenerator/generateAnsibleConfig');
 const generateTerraformConfig = require('../lib/configGenerator/generateTerraformConfig');
 
@@ -10,39 +8,6 @@ async function main() {
 
   await generateAnsibleConfig(network, networkName, masternodesCount);
   await generateTerraformConfig(network, networkName, masternodesCount);
-
-  const env = '# Terraform remote backend configuration https://www.terraform.io/docs/backends/types/s3.html\n'
-    + 'TERRAFORM_S3_BUCKET=""\n'
-    + 'TERRAFORM_S3_KEY=""\n'
-    + 'TERRAFORM_DYNAMODB_TABLE=""\n'
-    + '\n'
-    + '# Absolute paths to private and public keys for SSH access to an infrastructure\n'
-    + 'PRIVATE_KEY_PATH=""\n'
-    + 'PUBLIC_KEY_PATH=""\n'
-    + '\n'
-    + '# AWS credentials are used by Terraform for creating\n'
-    + '# infrastructure and by Ansible for fetching images from AWS ECR.\n'
-    + '#\n'
-    + '# You should specify credentials for both\n'
-    + '# Ansible and Terraform or specify a particular\n'
-    + '# configuration using "TERRAFORM_" and "ANSIBLE_" prefixes\n'
-    + '\n'
-    + '# AWS_PROFILE="" # You can use AWS_PROFILE instead of AWS credentials\n'
-    + 'AWS_ACCESS_KEY_ID=""\n'
-    + 'AWS_SECRET_ACCESS_KEY=""\n'
-    + 'AWS_REGION=""\n'
-    + '\n'
-    + '# TERRAFORM_AWS_PROFILE=""\n'
-    + '# TERRAFORM_AWS_ACCESS_KEY_ID=""\n'
-    + '# TERRAFORM_AWS_SECRET_ACCESS_KEY=""\n'
-    + '# TERRAFORM_AWS_REGION=""\n'
-    + '\n'
-    + '# ANSIBLE_AWS_PROFILE=""\n'
-    + '# ANSIBLE_AWS_ACCESS_KEY_ID=""\n'
-    + '# ANSIBLE_AWS_SECRET_ACCESS_KEY=""\n'
-    + '# ANSIBLE_AWS_REGION=""\n';
-
-  fs.writeFileSync('networks/.env', env);
 }
 
 main().catch(console.error);

--- a/lib/cli/init.sh
+++ b/lib/cli/init.sh
@@ -23,10 +23,40 @@ VPN_CONFIG_PATH="networks/$NETWORK_NAME.ovpn"
 
 if [ ! -f networks/.env ]; then
 
-    print_error "Configuration .env file not found
+    echo "Configuration .env file not found.
 
-Please create and configure '.env' file."
+Generating blank '.env' file... "
 
-else
+  cat > networks/.env<< EOF
+# Terraform remote backend configuration https://www.terraform.io/docs/backends/types/s3.html
+TERRAFORM_S3_BUCKET=""
+TERRAFORM_S3_KEY=""
+TERRAFORM_DYNAMODB_TABLE=""
+# Absolute paths to private and public keys for SSH access to an infrastructure
+PRIVATE_KEY_PATH=""
+PUBLIC_KEY_PATH=""
+# AWS credentials are used by Terraform for creating
+# infrastructure and by Ansible for fetching images from AWS ECR.
+#
+# You should specify credentials for both
+# Ansible and Terraform or specify a particular
+# configuration using "TERRAFORM_" and "ANSIBLE_" prefixes
+# AWS_PROFILE="" # You can use AWS_PROFILE instead of AWS credentials
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""
+AWS_REGION=""
+# TERRAFORM_AWS_PROFILE=""
+# TERRAFORM_AWS_ACCESS_KEY_ID=""
+# TERRAFORM_AWS_SECRET_ACCESS_KEY=""
+# TERRAFORM_AWS_REGION=""
+# ANSIBLE_AWS_PROFILE=""
+# ANSIBLE_AWS_ACCESS_KEY_ID=""
+# ANSIBLE_AWS_SECRET_ACCESS_KEY=""
+# ANSIBLE_AWS_REGION=""
+EOF
+
+fi
+
+if [ -f networks/.env ]; then
     source networks/.env
 fi


### PR DESCRIPTION
Checking for presence of the `.env` and loading its content was previously done in two places: in the `dash-network` command wrapper and in the `generate` command. This PR removes the duplicate code and moves the check into the init function.

## Issue being fixed or feature implemented
This fixes the chicken/egg problem of not having an `.env` file and not being able to create one because `init.sh` checks for its existence first, and also the problem of overwriting existing `.env` files when running `generate`.

## What was done?
Remove `.env` forced exit in `dash-network` and check/generate in `init.sh` instead of in the generate command.


## How Has This Been Tested?
Tested running `bin/generate` from shell and `dash-network generate` with docker.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
