### PR TITLE
fix: adjust port declarations

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -53,7 +53,10 @@ dashd_home: /dash
 # dash_network_name:
 dash_devnet_version: 1
 
-dashd_port: 20001
+dash_ports:
+  "testnet": 19999
+  "livenet": 9999
+dashd_port: "{{ dash_ports[dash_network] or 20001 }}"
 
 # DashCore RPC settings
 dashd_rpc_allow_public: false

--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -62,13 +62,13 @@ externalip={{ dashd_externalip }}
 dnsseed=0
 allowprivatenet={{ dashd_allowprivatenet }}
 
-[{{ dash_network }}]
-
-rpcport={{ dashd_rpc_port }}
-
 {% if masternode is defined %}
 masternodeblsprivkey={{ masternode.operator.private_key }}
 {% endif %}
+
+[{{ dash_network }}]
+
+rpcport={{ dashd_rpc_port }}
 
 # external network
 {% if dashd_listen %}


### PR DESCRIPTION
Adjust port declarations

## Issue being fixed or feature implemented
testnet masternodes weren't starting in masternode mode


## What was done?
Move `masternodeblsprivkey` declaration above `[network]` declaration and specify default ports for testnet/mainnet networks.

## How Has This Been Tested?
Ran in ansible, masternode responds properly to `dash-cli masternode status`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
