### PR TITLE
fix: move network section declaration

### DIFF
--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -62,13 +62,13 @@ externalip={{ dashd_externalip }}
 dnsseed=0
 allowprivatenet={{ dashd_allowprivatenet }}
 
-[{{ dash_network }}]
-
-rpcport={{ dashd_rpc_port }}
-
 {% if masternode is defined %}
 masternodeblsprivkey={{ masternode.operator.private_key }}
 {% endif %}
+
+[{{ dash_network }}]
+
+rpcport={{ dashd_rpc_port }}
 
 # external network
 {% if dashd_listen %}


### PR DESCRIPTION
Moves the network section declaration to work with new dash core config syntax

## Issue being fixed or feature implemented
testnet masternodes weren't starting in masternode mode

## What was done?
Moved the network section declaration below the bls key

## How Has This Been Tested?
On testnet, masternodes now start in masternode mode

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
