### PR TITLE
fix: `main_domain` option doesn't work for testnet

### DIFF
--- a/lib/cli/init.sh
+++ b/lib/cli/init.sh
@@ -10,6 +10,7 @@ if grep -q "devnet" <<< "$NETWORK_NAME"; then
     fi
 elif [[ " ${networks[@]} " =~ " ${NETWORK_NAME} " ]]; then
     NETWORK="$NETWORK_NAME"
+    NETWORK_DEVNET_NAME="$NETWORK_NAME"
 else
     print_error "Invalid network name '$NETWORK_NAME'. Supported networks: regtest, devnet-<name>, testnet, mainnet"
 fi

--- a/lib/cli/init.sh
+++ b/lib/cli/init.sh
@@ -10,7 +10,6 @@ if grep -q "devnet" <<< "$NETWORK_NAME"; then
     fi
 elif [[ " ${networks[@]} " =~ " ${NETWORK_NAME} " ]]; then
     NETWORK="$NETWORK_NAME"
-    NETWORK_DEVNET_NAME="$NETWORK_NAME"
 else
     print_error "Invalid network name '$NETWORK_NAME'. Supported networks: regtest, devnet-<name>, testnet, mainnet"
 fi

--- a/lib/cli/terraform.sh
+++ b/lib/cli/terraform.sh
@@ -46,8 +46,14 @@ function terraform_run_command() {
         config_path_arg="-var-file=../../$TERRAFORM_CONFIG_PATH";
     fi
 
+    if [[ $NETWORK == "devnet" ]]; then
+        PUBLIC_NETWORK_NAME=$NETWORK_DEVNET_NAME
+    else
+        PUBLIC_NETWORK_NAME=$NETWORK_NAME
+    fi
+
     terraform ${1}  -var "public_key_path=$PUBLIC_KEY_PATH" \
-                    -var "public_network_name=$NETWORK_DEVNET_NAME" \
+                    -var "public_network_name=$PUBLIC_NETWORK_NAME" \
                     ${config_path_arg}
 
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -132,7 +132,7 @@ resource "aws_route53_record" "faucet" {
   name    = "faucet.${var.public_network_name}.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [aws_elb.web[0].dns_name]
+  records = [join("", aws_elb.web[*].dns_name)]
 
   count = length(var.main_domain) > 1 ? 1 : 0
 }
@@ -142,7 +142,7 @@ resource "aws_route53_record" "insight" {
   name    = "insight.${var.public_network_name}.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [aws_elb.web[0].dns_name]
+  records = [join("", aws_elb.web[*].dns_name)]
 
   count = length(var.main_domain) > 1 ? 1 : 0
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -89,7 +89,7 @@ resource "aws_elb" "web" {
 
   subnets = aws_subnet.public.*.id
 
-  count = var.web_count > 1 ? 1 : 0
+  count = var.web_count >= 1 ? 1 : 0
 
   security_groups = [
     aws_security_group.elb.id,
@@ -132,7 +132,7 @@ resource "aws_route53_record" "faucet" {
   name    = "faucet.${var.public_network_name}.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [join("", aws_elb.web[*].dns_name)]
+  records = [aws_elb.web[count.index].dns_name]
 
   count = length(var.main_domain) > 1 ? 1 : 0
 }
@@ -142,7 +142,7 @@ resource "aws_route53_record" "insight" {
   name    = "insight.${var.public_network_name}.${var.main_domain}"
   type    = "CNAME"
   ttl     = "300"
-  records = [join("", aws_elb.web[*].dns_name)]
+  records = [aws_elb.web[count.index].dns_name]
 
   count = length(var.main_domain) > 1 ? 1 : 0
 }


### PR DESCRIPTION
This PR fixes errors preventing DNS registration when using testnet config. Together with [this PR](https://github.com/dashevo/dash-network-configs/pull/38) to the config, it should resolve DNS errors for testnet.

## Issue being fixed or feature implemented
Terraform was failing with:
```
data.template_file.ansible_inventory: Refreshing state...

Error: Invalid index

  on main.tf line 136, in resource "aws_route53_record" "faucet":
 136:   records = [aws_elb.web[0].dns_name]
    |----------------
    | aws_elb.web is empty tuple

The given key does not identify an element in this collection value.


Error: Invalid index

  on main.tf line 147, in resource "aws_route53_record" "insight":
 147:   records = [aws_elb.web[0].dns_name]
    |----------------
    | aws_elb.web is empty tuple

The given key does not identify an element in this collection value.
```

## What was done?
- instantiate required `public_network_name` in variable by specifying `NETWORK_DEVNET_NAME` with non-devnet networks
- user `>=` operator instead of `>` to ensure count is `1` when creating `aws_elb`

This should result in tuples for `aws_elb.web[0].dns_name` existing when subsequently attempting to create routes.

## How Has This Been Tested?
`dash-network list testnet` works again, `dash-network deploy -i testnet` indicates it will deploy records correctly as follows:
```
# aws_elb.web[0] will be created
  + resource "aws_elb" "web" {
      + arn                         = (known after apply)
      + availability_zones          = (known after apply)
      + connection_draining         = false
      + connection_draining_timeout = 300
      + cross_zone_load_balancing   = true
      + dns_name                    = (known after apply)
      + id                          = (known after apply)
      + idle_timeout                = 60
      + instances                   = [
          + "i-0d95571ca4ca6cecd",
        ]
      + internal                    = (known after apply)
      + name                        = "testnet"
      + security_groups             = [
          + "sg-0e4a916801c9749e8",
        ]
      + source_security_group       = (known after apply)
      + source_security_group_id    = (known after apply)
      + subnets                     = [
          + "subnet-05fa2e7ea1d0d5f7b",
          + "subnet-09df015ece18f95f7",
          + "subnet-0d7b45223ef4ea9c4",
        ]
      + tags                        = {
          + "DashNetwork" = "testnet"
          + "Name"        = "dn-testnet-web"
        }
      + zone_id                     = (known after apply)

      + health_check {
          + healthy_threshold   = 2
          + interval            = 20
          + target              = "HTTP:80/"
          + timeout             = 3
          + unhealthy_threshold = 2
        }

      + listener {
          + instance_port     = 3001
          + instance_protocol = "http"
          + lb_port           = 3001
          + lb_protocol       = "http"
        }
      + listener {
          + instance_port     = 80
          + instance_protocol = "http"
          + lb_port           = 80
          + lb_protocol       = "http"
        }
    }

  # aws_route53_record.faucet[0] will be created
  + resource "aws_route53_record" "faucet" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "faucet.testnet.networks.dash.org"
      + records         = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + zone_id         = "Z0875113JJTK7DOU978T"
    }
...
```


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
