### PR TITLE
fix: wrong devnet chain name assert

### DIFF
--- a/test/smoke/core.js
+++ b/test/smoke/core.js
@@ -55,7 +55,7 @@ describe('Core', () => {
           const chainNames = {
             testnet: 'test',
             mainnet: 'main',
-            devnet: 'devnet',
+            devnet: network.name,
             regtest: 'regtest',
           };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Core chain name for devnet network consist devnet name as well so the current assert doesn't work for devnets

## What was done?
<!--- Describe your changes in detail -->
Compare chain name against `devnet-{name}`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
