### PR TITLE
fix: rescan after all keys are imported

### DIFF
--- a/ansible/roles/mn-fund-collateral/tasks/main.yml
+++ b/ansible/roles/mn-fund-collateral/tasks/main.yml
@@ -3,8 +3,11 @@
 # Requires "masternode_names" variable
 
 - name: import masternode collateral private key
-  command: 'dash-cli {{ masternode_wallet_rpc_args }} importprivkey {{ masternodes[item].collateral.private_key }}'
+  command: 'dash-cli {{ masternode_wallet_rpc_args }} importprivkey {{ masternodes[item].collateral.private_key }} "" false'
   with_items: '{{ masternode_names }}'
+
+- name: rescan blockchain
+  command: 'dash-cli {{ masternode_wallet_rpc_args }} rescanblockchain'
 
 # check
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
Rescannig the blockchain is slow on testnet. This PR changes behaviour to import all owner keys, then rescan blockchain instead of rescanning after each key import.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Network deploy was too slow on testnet

## What was done?
<!--- Describe your changes in detail -->
Rescan blockchain after all keys are imported instead of rescanning after each key import.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
