### PR TITLE
fix: removed `dash_devnet_version` being used in smoke tests

### DIFF
--- a/test/smoke/core.js
+++ b/test/smoke/core.js
@@ -1,7 +1,7 @@
 const createRpcClientFromConfig = require('../../lib/test/createRpcClientFromConfig');
 const getNetworkConfig = require('../../lib/test/getNetworkConfig');
 
-const { inventory, network, variables } = getNetworkConfig();
+const { inventory, network } = getNetworkConfig();
 
 const allHosts = inventory.masternodes.hosts.concat(
   inventory.wallet_nodes.hosts,
@@ -63,13 +63,8 @@ describe('Core', () => {
           expect(blockchainInfo[hostName].chain).to.equal(chainNames[network.type]);
           expect(networkactive).to.be.equal(true);
 
-          let networkName = network.name;
           if (network.type === 'devnet') {
-            if (variables.dash_devnet_version !== 1) {
-              networkName += `-${variables.dash_devnet_version}`;
-            }
-
-            expect(subversion).to.have.string(`(${network.type}=${networkName})/`);
+            expect(subversion).to.have.string(`(${network.type}=${network.name})/`);
           }
         });
 

--- a/test/smoke/tendermint.js
+++ b/test/smoke/tendermint.js
@@ -31,8 +31,8 @@ describe('Tendermint', () => {
         expect(error).to.be.undefined();
 
         let networkName = `dash-${network.name}`;
-        if (network.type === 'devnet' && variables.dash_devnet_version !== 1) {
-          networkName += `-${variables.dash_devnet_version}`;
+        if (network.type === 'devnet' && variables.tenderdash_chain_id !== undefined) {
+          networkName = `dash-${variables.tenderdash_chain_id}`;
         }
 
         expect(nodeInfo).to.deep.include({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removed `dash_devnet_version` being used in smoke tests that lead network type assertion to be failed.

## What was done?
<!--- Describe your changes in detail -->
- Removed `dash_devnet_version` from Core network assertion
- Used `tenderdash_chain_id` in Tenderdash assertion

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running smoke tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
