### PR TITLE
chore!: remove deprecated CNAME record for seed

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -147,18 +147,6 @@ resource "aws_route53_record" "insight" {
   count = length(var.main_domain) > 1 ? 1 : 0
 }
 
-# TODO: Deprecated. Remove on 0.14 version.
-
-resource "aws_route53_record" "masternodes-deprecated" {
-  zone_id = data.aws_route53_zone.main_domain[count.index].zone_id
-  name    = "seed.${var.public_network_name}.${var.main_domain}"
-  type    = "A"
-  ttl     = "300"
-  records = concat(aws_instance.masternode.*.public_ip)
-
-  count = length(var.main_domain) > 1 ? 1 : 0
-}
-
 locals {
   dns_record_length = 10 // recommended number of hosts per A record. Other way there might be problems with resolving of seeds in some regions.
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
seed.*.networks.dash domain was marked as deprecated in v0.13 and should be removed

## What was done?
<!--- Describe your changes in detail -->
- remove deprecated CNAME record for seed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Deprecated seed.*.networks.dash domain is no longer available

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
