### PR TITLE
feat: add llmq-qvvec-sync to dash.conf

### DIFF
--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -14,6 +14,8 @@ maxconnections=256
 debug={{ dashd_debug }}
 printtoconsole=1
 
+llmq-qvvec-sync=llmq_100_67
+
 {% if dashd_indexes %}
 # optional indices (required for Insight)
 txindex=1


### PR DESCRIPTION
llmq-qvvec-sync is used to synchronise quorum verification vectors

## Issue being fixed or feature implemented
Masternodes not deployed by the deploy tool do not contain this setting


## What was done?
Add llmq-qvvec-sync=llmq_100_67 to dash.conf


## How Has This Been Tested?
Tested in #217 then moved here


## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
