### PR TITLE
fix: build error due to outdated pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ COPY ansible/requirements.yml /ansible-requirements.yml
 
 COPY package*.json ./
 
+RUN pip3 install -U pip
+
 RUN pip3 install --upgrade netaddr awscli ansible && \
     ansible-galaxy install -r /ansible-requirements.yml && \
     npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,8 @@ COPY ansible/requirements.yml /ansible-requirements.yml
 
 COPY package*.json ./
 
-RUN pip3 install -U pip
-
-RUN pip3 install --upgrade netaddr awscli ansible && \
+RUN pip3 install -U pip && \
+    pip3 install --upgrade netaddr awscli ansible && \
     ansible-galaxy install -r /ansible-requirements.yml && \
     npm install
 


### PR DESCRIPTION
Use recent pip version to avoid build errors during install

## Issue being fixed or feature implemented
Build was erroring with `ModuleNotFoundError: No module named 'setuptools_rust'`


## What was done?
Add step to update pip version before installing requirements


## How Has This Been Tested?
Build completes successfully


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
