### PR TITLE
fix: pBFT block time went ahead on testnet

### DIFF
--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -352,7 +352,7 @@ skip_timeout_commit = false
 
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks = true
-create_empty_blocks_interval = "500ms"
+create_empty_blocks_interval = "10m"
 
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "100ms"

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -266,7 +266,7 @@ cache_size = 10000
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid
 # again in the future.
-keep-invalid-txs-in-cache = false
+keep-invalid-txs-in-cache = true
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -263,6 +263,11 @@ max_txs_bytes = 1073741824
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000
 
+# Do not remove invalid transactions from the cache (default: false)
+# Set to true if it's not possible for any invalid transaction to become valid
+# again in the future.
+keep-invalid-txs-in-cache = true
+
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
 max_tx_bytes = 1048576
@@ -347,7 +352,7 @@ skip_timeout_commit = false
 
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks = true
-create_empty_blocks_interval = "3m"
+create_empty_blocks_interval = "500ms"
 
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "100ms"

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -144,7 +144,7 @@ max_subscriptions_per_client = 5
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.
 # See https://github.com/tendermint/tendermint/issues/3435
-timeout_broadcast_tx_commit = "20s"
+timeout_broadcast_tx_commit = "30s"
 
 # Maximum size of request body, in bytes
 max_body_bytes = 1000000
@@ -266,7 +266,7 @@ cache_size = 10000
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid
 # again in the future.
-keep-invalid-txs-in-cache = true
+keep-invalid-txs-in-cache = false
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
@@ -339,7 +339,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "500ms"
+timeout_commit = "2s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -339,7 +339,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "2s"
+timeout_commit = "1s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
@@ -352,7 +352,7 @@ skip_timeout_commit = false
 
 # EmptyBlocks mode and possible interval between empty blocks
 create_empty_blocks = true
-create_empty_blocks_interval = "10m"
+create_empty_blocks_interval = "3m"
 
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "100ms"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pBFT block time went ahead due to super frequent block processing and some functionality based on it doesn't work properly. To mitigate this problem we need temporarily slow down block production.

## What was done?
<!--- Describe your changes in detail -->
- Increased `timeout_commit` to `1s`
- Icreased `timeout_broadcast_tx_commit` to `30s` to support new `timeout_commit`.
- Incresad `create_empty_blocks_interval` to `10m`
- Set `keep-invalid-txs-in-cache` to `true` to do not produce blocks for invalid transactions that already were invalidated.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With deploy

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
