### PR TITLE
fix!: tenderdash commands with underscore are deprecated

### DIFF
--- a/ansible/roles/mn-evo-services/tasks/tendermint.yml
+++ b/ansible/roles/mn-evo-services/tasks/tendermint.yml
@@ -18,7 +18,7 @@
   when: tendermint_home_dir.changed
 
 - name: get Tendermint node ID
-  command: docker-compose run --no-deps --rm --entrypoint='/usr/bin/tenderdash' tendermint show_node_id
+  command: docker-compose run --no-deps --rm --entrypoint='/usr/bin/tenderdash' tendermint show-node-id
   args:
     chdir: '{{ mn_evo_services_path }}'
   register: tendermint_node_id


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tenderdash 0.34.4 deprecates underscore in commands.

## What was done?
<!--- Describe your changes in detail -->
- Replace underscore to dash in tenderdash commands

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With deploy

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Tenderdash < 0.34.4 doesn't supported

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
