### PR TITLE
feat: eternal terminal

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -51,6 +51,7 @@
     - geerlingguy.pip
     - geerlingguy.docker
     - docker-options
+    - eternal-terminal
     - role: ecr-login
       when: aws_ecr_login
       tags: always

--- a/ansible/roles/eternal-terminal/tasks/main.yml
+++ b/ansible/roles/eternal-terminal/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Add the official ET repository
+  apt_repository:
+    repo: 'deb http://ppa.launchpad.net/jgmath2000/et/ubuntu/ {{ ansible_lsb.codename }} main'
+    state: present
+    update_cache: yes
+
+- name: Install ET
+  package:
+   name: et
+   state: present

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -15,6 +15,18 @@ resource "aws_security_group" "default" {
     ]
   }
 
+  # ET SSH access from anywhere
+  ingress {
+    from_port   = 2022
+    to_port     = 2022
+    protocol    = "tcp"
+    description = "ET SSH"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
   # Docker API
   ingress {
     from_port   = var.docker_port


### PR DESCRIPTION
This PR adds Eternal Terminal to all nodes

## Issue being fixed or feature implemented
Devs with unreliable internet connections cannot reliably stay connected to nodes for long periods over SSH. This tool allows for graceful resume in the event the connection drops or client IP changes.

## What was done?
Add Eternal Terminal package and open port


## How Has This Been Tested?
Tried connecting, it works.


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
