### PR TITLE
fix: incorrect logs server address in services template

### DIFF
--- a/terraform/aws/services_output.tf
+++ b/terraform/aws/services_output.tf
@@ -289,6 +289,7 @@ data "template_file" "services" {
     elb_host        = chomp(join("\n", aws_elb.web.*.dns_name))
     insight_port    = var.insight_port
     kibana_port     = var.kibana_port
+    logs_host       = aws_route53_record.logs[0].name
     vpn_host        = chomp(join("\n", aws_eip.vpn.*.public_ip))
     vpn_port        = var.vpn_port
   }

--- a/terraform/aws/templates/services/services.tpl
+++ b/terraform/aws/templates/services/services.tpl
@@ -32,7 +32,7 @@ ${elb_host}:${insight_port}/insight
 Kibana
 ======
 
-${elb_host}:${kibana_port}
+${logs_host}:${kibana_port}
 
 VPN
 ===


### PR DESCRIPTION
This PR fixes a minor bug in the Terraform services template output

## Issue being fixed or feature implemented
Terraform still outputs the web host address instead of the new logs host.

## What was done?
Modified output template to show correct information


## How Has This Been Tested?
Run against testnet config, output is good

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
