### PR TITLE
fix: sigs missing while adding et apt repository

### DIFF
--- a/ansible/roles/eternal-terminal/tasks/main.yml
+++ b/ansible/roles/eternal-terminal/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Add the official ET repository
   apt_repository:
-    repo: 'deb http://ppa.launchpad.net/jgmath2000/et/ubuntu/ {{ ansible_lsb.codename }} main'
+    repo: ppa:jgmath2000/et
     state: present
     update_cache: yes
 


### PR DESCRIPTION
This PR changes the method ansible uses to add apt repositories to ensure that the signatures are added first (if missing).

## Issue being fixed or feature implemented
ET deploy was failing with: `Failed to update apt cache: W:GPG error: http://ppa.launchpad.net/jgmath2000/et/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY CB4ADEA5B72A07A1, E:The repository 'http://ppa.launchpad.net/jgmath2000/et/ubuntu bionic InRelease' is not signed.`


## What was done?
Modify use of `ansible.builtin.apt_repository` to ensure PPA keys are installed before trying to fetch packages from repo.


## How Has This Been Tested?
Tested by running on palinka. ET is now running on all palinka nodes.


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
