### PR TITLE
fix: logs address does not resolve in dns

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -150,7 +150,7 @@ resource "aws_route53_record" "insight" {
 resource "aws_route53_record" "logs" {
   zone_id = data.aws_route53_zone.main_domain[count.index].zone_id
   name    = "logs.${var.public_network_name}.${var.main_domain}"
-  type    = "CNAME"
+  type    = "A"
   ttl     = "300"
   records = [aws_instance.logs[count.index].public_ip]
 


### PR DESCRIPTION
This PR fixes a bug to ensure the logs server is accessible through public DNS.

## Issue being fixed or feature implemented
`logs.testnet.networks.dash.org` did not resolve in some browsers.

## What was done?
Changed record type from CNAME to A. Now I know the difference ;)


## How Has This Been Tested?
Tested locally, again with VPN enabled and again with https://cachecheck.opendns.com/


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
