### PR TITLE
feat: make logs instance configurable

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -125,3 +125,4 @@ mn_evo_services_path: '{{ dashd_home }}/{{ mn_evo_services_compose_project_name 
 elastic_username: elastic
 elastic_password: 
 kibana_encryptionkey: 
+elastic_max_heap_size: 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -125,4 +125,4 @@ mn_evo_services_path: '{{ dashd_home }}/{{ mn_evo_services_compose_project_name 
 elastic_username: elastic
 elastic_password: 
 kibana_encryptionkey: 
-elastic_max_heap_size: 
+elastic_max_heap_size: 2g

--- a/ansible/roles/elastic-stack/templates/docker-compose.yml.j2
+++ b/ansible/roles/elastic-stack/templates/docker-compose.yml.j2
@@ -15,7 +15,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx3g"
+      ES_JAVA_OPTS: "-Xms1g -Xmx{{ elastic_max_heap_size }}g"
       ELASTIC_PASSWORD: {{ elastic_password }}
       # Use single node discovery in order to disable production mode and avoid bootstrap checks.
       # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html

--- a/ansible/roles/elastic-stack/templates/docker-compose.yml.j2
+++ b/ansible/roles/elastic-stack/templates/docker-compose.yml.j2
@@ -15,7 +15,7 @@ services:
       - "9200:9200"
       - "9300:9300"
     environment:
-      ES_JAVA_OPTS: "-Xms1g -Xmx{{ elastic_max_heap_size }}g"
+      ES_JAVA_OPTS: "-Xms1g -Xmx{{ elastic_max_heap_size }}"
       ELASTIC_PASSWORD: {{ elastic_password }}
       # Use single node discovery in order to disable production mode and avoid bootstrap checks.
       # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html

--- a/terraform/aws/instances.tf
+++ b/terraform/aws/instances.tf
@@ -230,7 +230,7 @@ resource "aws_instance" "logs" {
   count = var.logs_enabled ? 1 : 0
 
   ami                  = data.aws_ami.ubuntu.id
-  instance_type        = "t3.medium"
+  instance_type        = var.logs_node_instance_type
   key_name             = aws_key_pair.auth.id
   iam_instance_profile = aws_iam_instance_profile.monitoring.name
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -153,3 +153,8 @@ variable "logs_node_disk_size" {
   description = "Disk size of log nodes"
   default     = 100
 }
+
+variable "logs_node_instance_type" {
+  description = "Instance type of log nodes"
+  default     = "t3.medium"
+}


### PR DESCRIPTION
This PR allows configuration of the instance size of the logs node.


## Issue being fixed or feature implemented
Logs node was too slow and not configurable.

## What was done?
Specify defaults and add variables to configure AWS instance size and JVM heap size.


## How Has This Been Tested?
Tested on testnet


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
