### PR TITLE
fix: new llmq-qvvec-sync syntax in 0.17.0.0-rc4

### DIFF
--- a/ansible/roles/dashd/templates/dash.conf.j2
+++ b/ansible/roles/dashd/templates/dash.conf.j2
@@ -14,7 +14,7 @@ maxconnections=256
 debug={{ dashd_debug }}
 printtoconsole=1
 
-llmq-qvvec-sync=llmq_100_67
+llmq-qvvec-sync=llmq_100_67:0
 
 {% if dashd_indexes %}
 # optional indices (required for Insight)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Dash containers were failing with the following error after updating from `0.17.0.0-rc3` to `-rc4`:
```
Error: Invalid format in -llmq-qvvec-sync: llmq_100_67
```

## What was done?
Use new syntax for this setting


## How Has This Been Tested?
Tested on Palinka

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
