### PR TITLE
feat!: migrate Drive state tree to black3

### DIFF
--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -370,7 +370,7 @@ create_empty_blocks_interval = "3m"
 quorum_type = {{ platform_drive_validator_set_llmq_type }}
 
 # Set the App hash size
-app_hash_size = 20
+app_hash_size = 32
 
 # Reactor sleep duration parameters
 peer_gossip_sleep_duration = "100ms"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Merk library is updated in Drive to a newer version. It uses the blake3 hashing algorithm that has 32 bytes hash size.

## What was done?
<!--- Describe your changes in detail -->
- Set `app_hash_size` to 32 bytes in Tenderdash config

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running a local network with dashmate

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Drive with the previous version of Merk is not supported.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
