### PR TITLE
fix: mn-init unbans all nodes every time

### DIFF
--- a/ansible/roles/mn-init/tasks/main.yml
+++ b/ansible/roles/mn-init/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: get names of registered masternodes
   set_fact:
-      registered_masternode_names: "{{ registered_masternode_names + [ item ] }}"
+    registered_masternode_names: "{{ registered_masternode_names + [ item ] }}"
   when: get_protx_list_result.stdout|from_json|json_query("[?state.ownerAddress=='" + masternodes[item].owner.address + "']")
   with_items: '{{ groups["masternodes"] }}'
 
@@ -32,13 +32,17 @@
   debug:
     var: new_masternode_names
 
+- name: get list of banned masternodes from the wallet
+  set_fact:
+    banned_masternodes_list: "{{ get_protx_list_result.stdout|from_json|json_query('[?state.PoSeBanHeight > `0`]') }}"
+
 - set_fact:
     banned_masternode_names: []
 
 - name: get names of banned masternodes
   set_fact:
-      banned_masternode_names: "{{ banned_masternode_names + [ item ] }}"
-  when: get_protx_list_result.stdout|from_json|json_query("[?state.PoSeBanHeight > `0`]")
+    banned_masternode_names: "{{ banned_masternode_names + [ item ] }}"
+  when: banned_masternodes_list|json_query("[?state.ownerAddress=='" + masternodes[item].owner.address + "']")
   with_items: '{{ registered_masternode_names }}'
 
 - name: banned masternodes list


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some masternodes became banned during a recent network upgrade. This exposed a bug in the `mn-init` role that caused the deploy tool to try and create new ProUpServTxs for every node in the inventory, not just the banned nodes.

## What was done?
<!--- Describe your changes in detail -->
Modify query to search list of banned nodes instead of the full list

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
