### PR TITLE
feat: add devnet check

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -13,6 +13,7 @@ Usage: deploy [options] <network_name>
 Options:
   -i        --only-infrastructure         - Only build infrastructure using Terraform
   -p        --only-provisioning           - Only provisioning using Ansible
+  -f        --force-deployment            - Force deployment of a devnet branch on a different devnet
   -a=<args> --ansible-args=<args>         - Pass extra arguments to ansible-playbook command
             --ansible-playbook=<playbook> - Specify custom playbook. Default: deploy
   -h        --help                        - Show help"
@@ -25,6 +26,9 @@ case ${i} in
     ;;
     -p|--only-provisioning)
     ONLY_PROVISIONING=1
+    ;;
+    -f|--force-deployment)
+    FORCED_DEPLOYMENT=1
     ;;
     -a=*|--ansible-args=*)
     ANSIBLE_ARGS="${i#*=}"
@@ -47,6 +51,14 @@ done
 . ./lib/cli/ansible.sh
 
 echo "Deploying $NETWORK_NAME network...";
+
+BRANCH=`git symbolic-ref --short -q HEAD`
+if [[ $BRANCH == "devnet-"* ]]; then
+    if [[ $BRANCH != $NETWORK_NAME ]] && [[ $FORCED_DEPLOYMENT != 1 ]]; then
+        echo "Wrong Devnet - Check you're in the correct branch. Use -f to force if you're sure"
+        exit 1
+    fi
+fi
 
 # Setup infrastructure using Terraform
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

if the branch has devnet-* there will be a small check to make sure we're deploying the correct devnet. Note this won't apply to any existing branches (master, v22-dev, etc) and will only impact on branches with devnet-

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will ensure we don't accidentally deploy incorrect devnet configs over each other, devnet-specific configs will be stored in branches in Dash Network Deploy repo. 

There is also a new -f command which will force the deployment *anyway* - this is to be used if you're sure you want to deploy one devnet config over a different devnet.


## What was done?
<!--- Describe your changes in detail -->
Small change to bin/deploy which checks if we're in a devnet branch, then checks if we're in the *correct* devnet branch. This ensures we cannot overwrite devnet-krupnik with devnet-malort changes. (examples, it applies to all devnet-* branches)

## How Has This Been Tested?
This has been tested by running the tool with various scenarios

1) Deploying master/v22/anything without the devnet- branch name will not trigger this code at all
2) Deploying devnet-malort config over devnet-krupnik triggers an error
3) Deploying devnet-malort config over devnet-krupnik with -f continues anyway
4) Deploying devnet-malort branch to devnet-malort continues anyway.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
