### PR TITLE
fix: platform logs not present filebeat error

### DIFF
--- a/ansible/roles/elastic-beats/tasks/main.yml
+++ b/ansible/roles/elastic-beats/tasks/main.yml
@@ -35,7 +35,7 @@
                   overwrite_keys: true
                   target_prefix: ""
           - type: log
-            enabled: true
+            enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
             json.message_key: msg
             json.keys_under_root: false
             exclude_files: ['\.gz$']
@@ -112,7 +112,7 @@
                     - json.time
                   ignore_missing: true
           - type: container
-            enabled: true
+            enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
             json.message_key: _msg
             json.keys_under_root: false
             index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the `elastic-beats` role was deployed on a node without platform, filebeat would throw warnings that the services are not present

## What was done?
<!--- Describe your changes in detail -->
Only enable logging of platform services if platform is present

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On testnet against miner and seed nodes

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
