### PR TITLE
fix: the input device is not a TTY

### DIFF
--- a/bin/dash-network
+++ b/bin/dash-network
@@ -35,7 +35,7 @@ fi
 
 # Run container with specified command
 
-docker run -ti --rm \
+docker run -t --rm \
            --device /dev/net/tun \
            --cap-add=NET_ADMIN \
            -v "$PWD:/networks" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running smoke tests in CI from docker wrapped in the dash-network command resulted in the error `the input device is not a TTY`. It is not necessary to interact with the terminal when running smoke tests, so we should not keep STDIN open without being attached.

## What was done?
<!--- Describe your changes in detail -->
Remove interactive argument passed to `docker run`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
