### PR TITLE
chore: bump terraform version to 1.1.8

### DIFF
--- a/terraform/aws/versions.tf
+++ b/terraform/aws/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = "~> 1.0.5"
+  required_version = "~> 1.1.8"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to use a consistent major.minor version of terraform between devs and engineers using this tool

## What was done?
<!--- Describe your changes in detail -->
Bump required Terraform version to 1.1.8+

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally against AWS with Terraform 1.1.8 and 1.1.9

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Cannot use Terraform version older than 1.1.8

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
