### PR TITLE
Fix: 5 minute pause

### DIFF
--- a/ansible/roles/mn-createprotx/tasks/main.yml
+++ b/ansible/roles/mn-createprotx/tasks/main.yml
@@ -40,6 +40,10 @@
     num_blocks: 1
     balance_needed: 0
 
+- name: Pause for 5 minutes to allow propogation of protx's
+  pause:
+    minutes: 5
+
 # verify
 
 - name: get list of ProTx transactions from the wallet


### PR DESCRIPTION
A 5 minute pause is needed here for larger devnets *if* minimumblocks is above 4032 (which it will be for QR for future devnets)

The reason for this is the blocks are a lot slower (2.5m) for each subsequent block at this point so the protx's don't propagate properly until more blocks have passed. I suspect the larger the devnet, the more of an issue this is going to be, the 5 minute pause should work on most current devnets.

Unfortunately it skips the "wait 1 block" routine

A new PR will come eventually to fix this properly

Example: 
![image](https://user-images.githubusercontent.com/9920871/165935750-65e12047-8a01-4716-ab7c-c35191b59618.png)


## Issue being fixed or feature implemented
5 minute pause until we figure out what's causing some protx's to not be in the first block. 


## What was done?
5 minute pause


## How Has This Been Tested?
Deployed Malort


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have added or updated relevant unit/integration/functional/e2e tests
- [ x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
