### PR TITLE
feat: write protx values to config inventory file

### DIFF
--- a/ansible/roles/generate-blocks/tasks/main.yml
+++ b/ansible/roles/generate-blocks/tasks/main.yml
@@ -8,8 +8,8 @@
       - regtest
       - devnet
 
-- include: regtest_generate.yml
+- include_tasks: regtest_generate.yml
   when: dash_network in generate_networks
 
-- include: wait_for_blocks.yml
+- include_tasks: wait_for_blocks.yml
   when: dash_network not in generate_networks

--- a/ansible/roles/mn-createprotx/tasks/main.yml
+++ b/ansible/roles/mn-createprotx/tasks/main.yml
@@ -12,7 +12,7 @@
 # fund
 
 - name: fund 1 coin for ProTx
-  include: ./roles/mn-fund-collateral/tasks/fund_collateral.yml
+  include_tasks: ./roles/mn-fund-collateral/tasks/fund_collateral.yml
   vars:
     masternode: "{{ masternodes[item] }}"
     masternode_name: "{{ item }}"
@@ -26,7 +26,7 @@
     num_blocks: 1
     balance_needed: 0
 
-- include: createprovidertx.yml
+- include_tasks: createprovidertx.yml
   vars:
     masternode: "{{ masternodes[item] }}"
     masternode_name: "{{ item }}"

--- a/ansible/roles/mn-fund-collateral/tasks/main.yml
+++ b/ansible/roles/mn-fund-collateral/tasks/main.yml
@@ -40,7 +40,7 @@
 
 # fund
 
-- include: fund_collateral.yml
+- include_tasks: fund_collateral.yml
   vars:
     masternode: "{{ masternodes[item] }}"
     masternode_name: "{{ item }}"

--- a/ansible/roles/mn-init/tasks/main.yml
+++ b/ansible/roles/mn-init/tasks/main.yml
@@ -89,3 +89,7 @@
   vars:
     masternode_names: "{{ banned_masternode_names }}"
   when: banned_masternode_names|length > 0
+
+- name: update config with protx values
+  include_role:
+    name: mn-protx-config

--- a/ansible/roles/mn-protx-config/tasks/find-protx.yml
+++ b/ansible/roles/mn-protx-config/tasks/find-protx.yml
@@ -4,7 +4,7 @@
 
 - name: get protx of registered masternodes
   set_fact:
-    registered_masternode_protx: "{{ registered_masternode_protx + [ { item: { 'protx': inner_item } } ] }}"
+    registered_masternode_protx: "{{ registered_masternode_protx + [ { 'masternode': item, 'protx': inner_item } ] }}"
   loop: "{{ get_protx_list_result.stdout|from_json|json_query(\"[?state.ownerAddress=='\" + masternode.owner.address + \"'].proTxHash\") }}"
   loop_control:
     loop_var: inner_item

--- a/ansible/roles/mn-protx-config/tasks/find-protx.yml
+++ b/ansible/roles/mn-protx-config/tasks/find-protx.yml
@@ -1,0 +1,10 @@
+---
+
+# Requires "masternode" and "masternode_name" variables
+
+- name: get protx of registered masternodes
+  set_fact:
+    registered_masternode_protx: "{{ registered_masternode_protx + [ { item: { 'protx': inner_item } } ] }}"
+  loop: "{{ get_protx_list_result.stdout|from_json|json_query(\"[?state.ownerAddress=='\" + masternode.owner.address + \"'].proTxHash\") }}"
+  loop_control:
+    loop_var: inner_item

--- a/ansible/roles/mn-protx-config/tasks/main.yml
+++ b/ansible/roles/mn-protx-config/tasks/main.yml
@@ -23,23 +23,12 @@
     masternode_name: "{{ item }}"
   with_items: '{{ registered_masternode_names }}'
 
-- name: read config from yaml file
-  include_vars: 
-    file: ../../../networks/{{ dash_network_name }}.yml # relative to this file
-    name: config
-
-- name: add protx values to config
-  set_fact:
-    config: "{{ config | combine(protx_data, recursive=True) }}"
-  vars: 
-    protx_data:
-      masternodes:
-        '{{ item }}'
-  with_items: '{{ registered_masternode_protx }}'
-
-- name: write config to yaml file
+- name: write protx values to inventory file
   become: no
   delegate_to: localhost
-  copy:
-    content: "---\n\n{{ config | to_nice_yaml(indent=2) }}"
-    dest: ../networks/{{ dash_network_name }}.yml # relative to playbook
+  lineinfile:
+    path: ../networks/{{ dash_network_name }}.inventory # relative to playbook
+    regexp: '^({{ item.masternode }} (?!.*protx=).*)'
+    line: '\1 protx={{ item.protx }}'
+    backrefs: yes
+  with_items: '{{ registered_masternode_protx }}'

--- a/ansible/roles/mn-protx-config/tasks/main.yml
+++ b/ansible/roles/mn-protx-config/tasks/main.yml
@@ -41,9 +41,5 @@
   become: no
   delegate_to: localhost
   copy:
-    content: 
-      ---
-      
-
-      {{ config | to_nice_yaml }}
+    content: "---\n\n{{ config | to_nice_yaml(indent=2) }}"
     dest: ../networks/{{ dash_network_name }}.yml # relative to playbook

--- a/ansible/roles/mn-protx-config/tasks/main.yml
+++ b/ansible/roles/mn-protx-config/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: get list of ProTx transactions from the wallet
+  command: dash-cli protx list wallet true
+  register: get_protx_list_result
+
+- set_fact:
+    registered_masternode_names: []
+
+- name: get names of registered masternodes
+  set_fact:
+    registered_masternode_names: "{{ registered_masternode_names + [ item ] }}"
+  when: get_protx_list_result.stdout|from_json|json_query("[?state.ownerAddress=='" + masternodes[item].owner.address + "']")
+  with_items: '{{ groups["masternodes"] }}'
+
+- set_fact:
+    registered_masternode_protx: []
+
+- name: get list of registered masternode protx
+  include_tasks: find-protx.yml
+  vars:
+    masternode: "{{ masternodes[item] }}"
+    masternode_name: "{{ item }}"
+  with_items: '{{ registered_masternode_names }}'
+
+- name: read config from yaml file
+  include_vars: 
+    file: ../../../networks/{{ dash_network_name }}.yml # relative to this file
+    name: config
+
+- name: add protx values to config
+  set_fact:
+    config: "{{ config | combine(protx_data, recursive=True) }}"
+  vars: 
+    protx_data:
+      masternodes:
+        '{{ item }}'
+  with_items: '{{ registered_masternode_protx }}'
+
+- name: write config to yaml file
+  become: no
+  delegate_to: localhost
+  copy:
+    content: 
+      ---
+      
+
+      {{ config | to_nice_yaml }}
+    dest: ../networks/{{ dash_network_name }}.yml # relative to playbook

--- a/ansible/roles/mn-unban/tasks/main.yml
+++ b/ansible/roles/mn-unban/tasks/main.yml
@@ -3,7 +3,7 @@
 # Requires "masternodes" and "masternode_names" variables
 
 - name: get list of banned masternode protx
-  include: find-protx.yml
+  include_tasks: find-protx.yml
   vars:
     masternode: "{{ masternodes[item] }}"
     masternode_name: "{{ item }}"
@@ -12,7 +12,7 @@
 # unban
 
 - name: create ProUpServTx for banned masternodes
-  include: createproupservtx.yml
+  include_tasks: createproupservtx.yml
   vars:
     masternode: "{{ masternodes[item] }}"
     masternode_name: "{{ item }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running test suite against an arbitrary network in CI requires specification of the protx values in the new `MASTERNODE_REWARD_SHARES_OWNER_PRO_REG_TX_HASH` variable. We therefore need to add protx values for the registered masternodes to the inventory after they have been registered on the network, half way through the deploy process.

## What was done?
<!--- Describe your changes in detail -->
- Fix warnings about deprecated Ansible `include` statement in all files
- Add a new task in the `mn-init` role to write the protx values to the inventory file when known

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally against valhalla and testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Preview output is here: https://github.com/dashevo/dash-network-configs/pull/66

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
