### PR TITLE
fix: generate command not found with core 18.1.0

### DIFF
--- a/ansible/roles/generate-blocks/tasks/regtest_generate.yml
+++ b/ansible/roles/generate-blocks/tasks/regtest_generate.yml
@@ -1,12 +1,12 @@
 ---
 
 - name: generate fixed amount of blocks
-  shell: dash-cli {{ faucet_rpc_args }} generate {{ num_blocks }} > /dev/null
+  shell: dash-cli {{ faucet_rpc_args }} generatetoaddress {{ num_blocks }} {{ miner_payment_address }} > /dev/null
   when: num_blocks|int > 0
 
 # TODO avoid first call if not needed
 - name: generate enough blocks to have {{ balance_needed|default(0) }} coins
-  shell: dash-cli {{ faucet_rpc_args }} generate 10 > /dev/null && dash-cli {{ faucet_rpc_args }} getbalance
+  shell: dash-cli {{ faucet_rpc_args }} generatetoaddress 10 {{ miner_payment_address }} > /dev/null && dash-cli {{ faucet_rpc_args }} getbalance
   when: balance_needed|float > 0
   register: balance_result
   until: balance_result.stdout|float >= balance_needed|float

--- a/ansible/roles/generate-firstblock/tasks/main.yml
+++ b/ansible/roles/generate-firstblock/tasks/main.yml
@@ -14,5 +14,5 @@
 - debug: var=initial_block_count
 
 - name: generate first block
-  command: dash-cli generate 1
+  command: dash-cli generatetoaddress 1 {{ miner_payment_address }}
   when: initial_block_count|int < required_block_count|int


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`dash-cli generate` returns `error message: Method not found` with 18.1.x builds of Dash Core

## What was done?
<!--- Describe your changes in detail -->
Replace `generate` with `generatetoaddress`, this command is backwards compatible so older versions of core should still work when runnings tasks that require blocks to be created.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested while deploying a devnet with the latest core build on `devnet-jammy`, a small devnet to test updating the Ubuntu base image.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
