### PR TITLE
fix: cannot attach to docker context with ubuntu key

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -54,7 +54,10 @@
         version: "1.22.0"
   roles:
     - geerlingguy.pip
-    - geerlingguy.docker
+    - role: geerlingguy.docker
+      vars:
+        docker_users:
+          - ubuntu
     - docker-options
     - eternal-terminal
     - role: ecr-login


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Devs want to be able to connect to the remote docker context, but the ssh key is associated with the `ubuntu` user account which is not in the `docker` group.

## What was done?
<!--- Describe your changes in detail -->
- Add `ubuntu` user to the `docker` group

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-sangsom` with Djavid

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
