### PR TITLE
chore: Remove unused ecr_login role

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -62,9 +62,6 @@
           - ubuntu
     - docker-options
     - eternal-terminal
-    - role: ecr-login
-      when: aws_ecr_login
-      tags: always
 
 # Install AWS monitoring scripts
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,7 +1,4 @@
 ---
-# Login to AWS ECR using passed from .env AWS credentials
-aws_ecr_login: false
-
 # Install Evolution Masternode services
 evo_services: false
 

--- a/ansible/roles/ecr-login/tasks/main.yml
+++ b/ansible/roles/ecr-login/tasks/main.yml
@@ -1,9 +1,0 @@
----
-
-- name: get ecr login command using environment vars
-  become: false
-  local_action: command aws ecr get-login --no-include-email
-  register: ecr_login_command
-
-- name: docker login
-  shell: "{{ ecr_login_command.stdout }}"

--- a/lib/cli/init.sh
+++ b/lib/cli/init.sh
@@ -36,8 +36,7 @@ TERRAFORM_DYNAMODB_TABLE=""
 # Absolute paths to private and public keys for SSH access to an infrastructure
 PRIVATE_KEY_PATH=""
 PUBLIC_KEY_PATH=""
-# AWS credentials are used by Terraform for creating
-# infrastructure and by Ansible for fetching images from AWS ECR.
+# AWS credentials are used by Terraform for creating infrastructure
 #
 # You should specify credentials for both
 # Ansible and Terraform or specify a particular


### PR DESCRIPTION
## Issue being fixed or feature implemented

We don't use ECR any more and this removes an unnecessary role.
