### PR TITLE
chore: Remove dashd_evo_image (use dashd_image)

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -63,7 +63,6 @@ insight_port: 3001
 
 # DashCore Docker image
 dashd_image: dashpay/dashd
-dashd_evo_image: dashpay/dashd:evo-latest
 
 dashd_user: dash
 dashd_group: dash

--- a/ansible/roles/dash-cli/tasks/main.yml
+++ b/ansible/roles/dash-cli/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: pull dashd image
-  shell: docker pull {{ dashd_evo_image if evo_services else dashd_image }}
+  shell: docker pull {{ dashd_image }}
 
 - name: copy dash-cli from docker container
-  shell: docker run --rm -v /tmp:/host-tmp {{ dashd_evo_image if evo_services else dashd_image }} cp /usr/local/bin/dash-cli /host-tmp/ && mv /tmp/dash-cli /usr/local/bin/dash-cli
+  shell: docker run --rm -v /tmp:/host-tmp {{ dashd_image }} cp /usr/local/bin/dash-cli /host-tmp/ && mv /tmp/dash-cli /usr/local/bin/dash-cli

--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -43,7 +43,7 @@
     state: started
     restart: '{{ dash_config_state is changed }}'
     restart_policy: always
-    image: '{{ dashd_evo_image if evo_services else dashd_image }}'
+    image: '{{ dashd_image }}'
     pull: true
     user: '{{ dash_user_id.stdout }}:{{ dash_group_id.stdout }}'
     working_dir: '{{ dashd_home }}'

--- a/lib/configGenerator/generateAnsibleConfig.js
+++ b/lib/configGenerator/generateAnsibleConfig.js
@@ -41,7 +41,7 @@ async function generateAnsibleConfig(network, networkName, masternodesCount, see
   config.drive_image = 'dashpay/drive';
   config.dapi_image = 'dashpay/dapi';
   config.dapi_envoy_image = 'envoyproxy/envoy:v1.16-latest';
-  config.dashd_evo_image = 'dashpay/dashd';
+  config.dashd_image = 'dashpay/dashd';
   config.tendermint_image = 'dashpay/tenderdash';
   config.tenderdash_chain_id = networkName;
 


### PR DESCRIPTION
This consolidates the 2 variables `dashd_evo_image` and `dashd_image`. There is no need for both of them, since they are both refer to the same service.

This is catching me out on some changes I'm making on master even through it's been merged in `v0.23-dev`,  so I'm opening this as a hotfix PR into master as well. There should be no reason this can't be merged for testnet, not sure about `devnet-333`.