### PR TITLE
fix: Use getgovernanceinfo in RPC check

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -54,7 +54,7 @@
     container_default_behavior: compatibility
 
 - name: wait for rpc to be available
-  shell: dash-cli getblockchaininfo
+  shell: dash-cli getgovernanceinfo
   register: task_result
   until: task_result.rc == 0
   retries: 5


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `getblockchaininfo` call is heavy, consumes a lot of resources. Since we are only using this to check if RPC is ready, we can use something light like `getgovernanceinfo` instead. This saves 2-3 seconds each time it's called.

## What was done?

Changed `getblockchaininfo` to `getgovernanceinfo` in dashd RPC check.

## How Has This Been Tested?

I tested this by running the dashd play on a testnet masternode, once.

## Breaking Changes

n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation