### PR TITLE
chore: tidy sentinel docker-compose, enable debug

### DIFF
--- a/ansible/roles/mn-sentinel/templates/docker-compose.yml
+++ b/ansible/roles/mn-sentinel/templates/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - RPCPASSWORD={{ dashd_rpc_password }}
       - RPCHOST={{ private_ip }}
       - RPCPORT={{ dashd_rpc_port }}
-      # Sentinel only supports mainnet and testnet at the moment
-      - NETWORK={{ 'mainnet' if dash_network == 'mainnet' else 'testnet' }}
       # Bypass scheduler
-      - SENTINEL_ARGS=-b
+      - SENTINEL_ARGS=--bypass-scheduler
+      - SENTINEL_DEBUG=1


### PR DESCRIPTION
## Issue being fixed or feature implemented

This just tidies the Sentinel docker-compose file a bit and enables debug logging.

The NETWORK variable is no longer used.


## What was done?

- Remove NETWORK env var
- Enable debug logging by setting SENTINEL_DEBUG
- Use long form of `--bypass-scheduler` option to reduce confusion.

## How Has This Been Tested?

I have tested this on several testnet MNs by running the mn-sentinel role

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation