### PR TITLE
refactor: reduce dash user complexity

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -7,19 +7,13 @@
 - name: Create dashd user
   user:
     name: '{{ dashd_user }}'
+    comment: 'Dash user'
     group: '{{ dashd_group }}'
-    append: False
     home: '{{ dashd_home }}'
+    create_home: yes
+    umask: '0002'
+  register: dash_user
 
-- name: get uid of dash user
-  shell: id -u {{ dashd_user }}
-  register: dash_user_id
-- name: get gid of dash user
-  shell: id -g {{ dashd_user }}
-  register: dash_group_id
-
-- name: create dash home/data dir
-  file: path={{ dashd_home }} state=directory mode='0750' owner='{{ dashd_user }}' group='{{ dashd_group }}'
 - name: create .dashcore dir
   file: path={{ dashd_home }}/.dashcore state=directory mode='0750' owner='{{ dashd_user }}' group='{{ dashd_group }}'
 - name: create .dashcore dir for root
@@ -45,7 +39,7 @@
     restart_policy: always
     image: '{{ dashd_evo_image if evo_services else dashd_image }}'
     pull: true
-    user: '{{ dash_user_id.stdout }}:{{ dash_group_id.stdout }}'
+    user: '{{ dash_user.uid }}:{{ dash_user.group }}'
     working_dir: '{{ dashd_home }}'
     volumes:
     - '{{ dashd_home }}:/dash'


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Dash user plays are excessive and can be reduced to 1 play using user module.

- Shell outs not required for uid/gid, this is in the user module register.
- The home dir creation can be done in the user module too.
- The append is not useful here, since it defaults to false and no groups are listed anyway.
- It is helpful to add a user name comment

## What was done?

- Removed shell calls to id command.
- Make user module create home dir.
- Remove unused append argument.
- Add a user name comment

## How Has This Been Tested?

Ran on testnet masternode

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
