### PR TITLE
chore: Create dashcore dir for each user in a loop

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -64,6 +64,17 @@ insight_port: 3001
 # DashCore Docker image
 dashd_image: dashpay/dashd
 
+users_to_manage:
+- user: "ubuntu"
+  group: "ubuntu"
+  dir: "/home/ubuntu"
+- user: "root"
+  group: "root"
+  dir: "/root"
+- user: "dash"
+  group: "dash"
+  dir: "/dash"
+
 dashd_user: dash
 dashd_group: dash
 dashd_home: /dash

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -71,9 +71,9 @@ users_to_manage:
 - user: "root"
   group: "root"
   dir: "/root"
-- user: "dash"
-  group: "dash"
-  dir: "/dash"
+- user: "{{ dashd_user }}"
+  group: "{{ dashd_group }}"
+  dir: "{{ dashd_home }}"
 
 dashd_user: dash
 dashd_group: dash

--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -14,10 +14,14 @@
     umask: '0002'
   register: dash_user
 
-- name: create .dashcore dir
-  file: path={{ dashd_home }}/.dashcore state=directory mode='0750' owner='{{ dashd_user }}' group='{{ dashd_group }}'
-- name: create .dashcore dir for root
-  file: path=/root/.dashcore state=directory mode='0750' owner='root' group='root'
+- name: create .dashcore directory for each user
+  file:
+    path: "{{ item.dir }}/.dashcore"
+    state: "directory"
+    mode: 0755
+    owner: "{{ item.user }}"
+    group: "{{ item.group }}"
+  loop: "{{ users_to_manage }}"
 
 - name: Configure dashd
   template:


### PR DESCRIPTION
## Issue being fixed or feature implemented

User dashcore directories are not consistent among the 3 users that we have on MNs.

## What was done?

Adds a loop to create .dashcore directory for root, dash and ubuntu users.

## How Has This Been Tested?

Tested on some testnet masternodes using dashd role.

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
