### PR TITLE
chore: Consolidate dash.conf in one place and symlink

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -19,17 +19,22 @@
 - name: create .dashcore dir for root
   file: path=/root/.dashcore state=directory mode='0750' owner='root' group='root'
 
-- name: Configure dashd
+- name: Write dash.conf file in /etc/
   template:
     src: 'dash.conf.j2'
-    dest: '{{ dashd_home }}/.dashcore/dash.conf'
-    owner: '{{ dashd_user }}'
-    group: '{{ dashd_group }}'
-    mode: '0640'
+    dest: '/etc/dash.conf'
+    owner: 'root'
+    group: 'root'
+    mode: 0644
   register: dash_config_state
 
-- name: copy configuration to root user dir to make rpc work
-  shell: cp {{ dashd_home }}/.dashcore/dash.conf /root/.dashcore/
+- name: Symlink dash.conf to user dashcore directories to make rpc work
+  file:
+    path: "{{ item.dir }}/.dashcore/dash.conf"
+    src: "/etc/dash.conf"
+    state: link
+    force: yes
+  loop: "{{ users_to_manage }}"
 
 - name: create dashd container
   docker_container:


### PR DESCRIPTION
## Issue being fixed or feature implemented

The dash.conf file is copied around for different users for dash-cli ease of use, but it's easy to get divergent (differences in the file).

## What was done?

This PR adds the file in one single location (`/etc/dash.conf`) and then symlinks it into user directories so that dash-cli can be called easier by any of the users.

Needs #313 first.

## How Has This Been Tested?

Tested on some testnet masternodes using dashd role.

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
