### PR TITLE
fix: no value can start with v

### DIFF
--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -55,7 +55,7 @@ genesis-file = "config/genesis.json"
 
 is-masternode = {% if inventory_hostname in groups.masternodes %}true{% else %}false{% endif %}
 
-{% if inventory_hostname in groups.masternodes %}mode = validator{% endif %}
+{% if inventory_hostname in groups.masternodes %}mode = "validator"{% endif %}
 
 # Path to the JSON file containing the private key to use as a validator in the consensus protocol
 priv-validator-key-file = "config/priv_validator_key.json"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tenderdash 0.8 was crashing with `ERROR: While parsing config: (57, 8): no value can start with v`

## What was done?
<!--- Describe your changes in detail -->
Quote value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-jack-daniels

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
