### PR TITLE
chore: bump dashd-rpc to 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dashevo/dapi-client": "^0.22.0",
         "@dashevo/dashcore-lib": "~0.19.30",
-        "@dashevo/dashd-rpc": "^2.4.0",
+        "@dashevo/dashd-rpc": "^2.4.1",
         "@dashevo/wallet-lib": "~7.22.0",
         "@grpc/grpc-js": "^1.3.7",
         "bls-signatures": "^0.2.5",
@@ -204,9 +204,9 @@
       "integrity": "sha512-qZdePUDSLAZRXXV234bLBEUM0nAQjoxbcSwp1rqSMUe1rZ47mwU6OjciR/JvF1Oo8mc0ys6GE0ks0HGgqAZoGg=="
     },
     "node_modules/@dashevo/dashd-rpc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.0.tgz",
-      "integrity": "sha512-eXYNmt88GG1x1acNGeMFyUABNFgsABfgaG4TeXjyI6EASm7A45JSgyMVcoQmDzdmN5TBCAT1Pai9z3LpKFE4pg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.1.tgz",
+      "integrity": "sha512-Nw0v6j22LH3VtN3Ju2DyyAbvBm+7m7mzy4340Ho9C0K78pRpbfwXBXodyV6DKdKK9Bh4bNQhy30zvZHl9+005A==",
       "dependencies": {
         "async": "^3.2.0",
         "bluebird": "^3.7.2"
@@ -9807,9 +9807,9 @@
       }
     },
     "@dashevo/dashd-rpc": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.0.tgz",
-      "integrity": "sha512-eXYNmt88GG1x1acNGeMFyUABNFgsABfgaG4TeXjyI6EASm7A45JSgyMVcoQmDzdmN5TBCAT1Pai9z3LpKFE4pg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.1.tgz",
+      "integrity": "sha512-Nw0v6j22LH3VtN3Ju2DyyAbvBm+7m7mzy4340Ho9C0K78pRpbfwXBXodyV6DKdKK9Bh4bNQhy30zvZHl9+005A==",
       "requires": {
         "async": "^3.2.0",
         "bluebird": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@dashevo/dapi-client": "^0.22.0",
     "@dashevo/dashcore-lib": "~0.19.30",
-    "@dashevo/dashd-rpc": "^2.4.0",
+    "@dashevo/dashd-rpc": "^2.4.1",
     "@dashevo/wallet-lib": "~7.22.0",
     "@grpc/grpc-js": "^1.3.7",
     "bls-signatures": "^0.2.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use of dashd-rpc 2.4.0 was causing smoke tests to throw errors related to timeouts. dashd-rpc 2.4.1 fixes this.

## What was done?
<!--- Describe your changes in detail -->
Update to dashd-rpc 2.4.1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally against testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
