### PR TITLE
feat: Write and use docker-compose file for dashcore

### DIFF
--- a/ansible/roles/dashd/defaults/main.yml
+++ b/ansible/roles/dashd/defaults/main.yml
@@ -14,3 +14,6 @@ dashd_private_cidr: '{{ private_ip|ipsubnet(dashd_private_net_prefix) }}'
 
 # When running devnet/regtest in local networks, we have to allow RFC1918/private addresses
 dashd_allowprivatenet: '{% if dashd_externalip|ipaddr("private") == dashd_externalip %}1{% else %}0{% endif %}'
+
+dashd_compose_project_name: dashcore
+dashd_compose_path: '{{ dashd_home }}/{{ dashd_compose_project_name }}'

--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -40,21 +40,28 @@
     force: yes
   loop: "{{ users_to_manage }}"
 
-- name: create dashd container
-  docker_container:
-    name: dashd
-    state: started
-    restart: '{{ dash_config_state is changed }}'
-    restart_policy: always
-    image: '{{ dashd_image }}'
-    pull: true
-    user: '{{ dash_user.uid }}:{{ dash_user.group }}'
-    working_dir: '{{ dashd_home }}'
-    volumes:
-    - '{{ dashd_home }}:/dash'
-    network_mode: host
-    command: 'dashd -conf={{ dashd_home }}/.dashcore/dash.conf -datadir={{ dashd_home }}/.dashcore'
-    container_default_behavior: compatibility
+- name: Create dashcore docker-compose dir
+  file:
+    path: '{{ dashd_compose_path }}'
+    state: directory
+    mode: 0755
+    recurse: true
+
+- name: Copy dashcore docker-compose file
+  template:
+    src: '{{ item }}.j2'
+    dest: '{{ dashd_compose_path }}/{{ item }}'
+    mode: 0644
+  loop:
+    - docker-compose.yml
+    - .env
+
+- name: Start dash core
+  docker_compose:
+    project_src: '{{ dashd_compose_path }}'
+    state: present
+    restarted: yes
+    pull: yes
 
 - name: wait for rpc to be available
   shell: dash-cli getblockchaininfo

--- a/ansible/roles/dashd/templates/.env.j2
+++ b/ansible/roles/dashd/templates/.env.j2
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME="{{ dashd_compose_project_name }}"

--- a/ansible/roles/dashd/templates/docker-compose.yml.j2
+++ b/ansible/roles/dashd/templates/docker-compose.yml.j2
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  dashcore:
+    image: {{ dashd_image }}
+    user: {{ dash_user.uid }}:{{ dash_user.group }}
+    container_name: dashd
+    restart: always
+    # TODO: use standard (bridge) networking
+    network_mode: host
+    #ports:
+    #- 0.0.0.0:{{ dashd_port }}:{{ dashd_port }}
+    #- 127.0.0.1:{{ dashd_rpc_port }}:{{ dashd_rpc_port }}
+    #- 127.0.0.1:{{ dashd_zmq_port }}:{{ dashd_zmq_port }}
+    volumes:
+    - "{{ dashd_home }}:/dash"
+    - "/etc/dash.conf:/etc/dash.conf"
+    command: ["dashd", "-conf=/etc/dash.conf", "-datadir=/dash/.dashcore"]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Currently dashcore must be managed only via the Ansible play. This will allow management of the dashcore container locally,  and give the ability to locally tweak the config (image, command, etc) via the docker-compose.yml file. This is (I believe) the only service we run that does not use docker-compose in the tool.

## What was done?

Adds a docker-compose.yml file for dashcore, and uses docker-compose to manage the container. Also removes the play which users docker container to manage it.

## How Has This Been Tested?

Tested on masternode on testnet.

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation