### PR TITLE
fix: Use getgovinfo in RPC check

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -57,7 +57,7 @@
     container_default_behavior: compatibility
 
 - name: wait for rpc to be available
-  shell: dash-cli getblockchaininfo
+  shell: dash-cli getgovernanceinfo
   register: task_result
   until: task_result.rc == 0
   retries: 5


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `getblockchaininfo` call is too heavy to be used as an RPC check.

## What was done?

Backport rpc check change (#310) into master. This is already in v0.23-dev but we need it today in master for testnet.

## How Has This Been Tested?

Tested on all masternodes and seed nodes on testnet.

## Breaking Changes

n/a

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
