### PR TITLE
fix: outdated tenderdash configs

### DIFF
--- a/ansible/roles/mn-evo-services/tasks/tendermint.yml
+++ b/ansible/roles/mn-evo-services/tasks/tendermint.yml
@@ -27,6 +27,7 @@
 - name: create Tendermint configs
   vars:
     template_seeds: "{{ groups.seed_nodes | reject('equalto', inventory_hostname) }}"
+    template_bootstrap_peers: "{{ groups.masternodes | reject('equalto', inventory_hostname) }}"
   template:
     src: 'roles/mn-evo-services/templates/tendermint/{{ item }}.j2'
     dest: '{{ mn_evo_services_path }}/tendermint/config/{{ item }}'

--- a/ansible/roles/mn-evo-services/tasks/tendermint.yml
+++ b/ansible/roles/mn-evo-services/tasks/tendermint.yml
@@ -26,8 +26,7 @@
 
 - name: create Tendermint configs
   vars:
-    template_seeds: "{{ groups.seed_nodes | reject('equalto', inventory_hostname) }}"
-    template_bootstrap_peers: "{{ groups.masternodes | reject('equalto', inventory_hostname) }}"
+    template_bootstrap_peers: "{{ groups.seed_nodes | reject('equalto', inventory_hostname) }}"
   template:
     src: 'roles/mn-evo-services/templates/tendermint/{{ item }}.j2'
     dest: '{{ mn_evo_services_path }}/tendermint/config/{{ item }}'

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -196,13 +196,10 @@ laddr = "tcp://0.0.0.0:26656"
 # to figure out the address.
 external-address = "{{ public_ip }}:26656"
 
-# Comma separated list of seed nodes to connect to
-seeds = ""
-
 # Comma separated list of nodes to keep persistent connections to
 persistent-peers = ""
 
-bootstrap-peers = "{% for seed in template_seeds %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+bootstrap-peers = "{% for seed in template_bootstrap_peers %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 # UPNP port forwarding
 upnp = false

--- a/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/config.toml.j2
@@ -56,6 +56,7 @@ genesis-file = "config/genesis.json"
 is-masternode = {% if inventory_hostname in groups.masternodes %}true{% else %}false{% endif %}
 
 {% if inventory_hostname in groups.masternodes %}mode = "validator"{% endif %}
+{% if inventory_hostname in groups.seed_nodes %}mode = "seed"{% endif %}
 
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node-key-file = "config/node_key.json"
@@ -196,10 +197,12 @@ laddr = "tcp://0.0.0.0:26656"
 external-address = "{{ public_ip }}:26656"
 
 # Comma separated list of seed nodes to connect to
-seeds = "{% for seed in template_seeds %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+seeds = ""
 
 # Comma separated list of nodes to keep persistent connections to
 persistent-peers = ""
+
+bootstrap-peers = "{% for seed in template_seeds %}{{ seed_nodes[seed].node_key.id }}@{{ hostvars[seed].public_ip }}:{{ tendermint_p2p_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 # UPNP port forwarding
 upnp = false

--- a/ansible/roles/mn-evo-services/templates/tendermint/genesis.json.j2
+++ b/ansible/roles/mn-evo-services/templates/tendermint/genesis.json.j2
@@ -22,8 +22,22 @@
     },
     "version": {}
   },
-  "threshold_public_key": null,
+ "validators": [
+    {
+      "pub_key": {
+        "type": "tendermint/PubKeyBLS12381",
+        "value": "imxjukh5hRY91Mvm/sfhQp6iSnICyvKMMdhY5Sq6Ej0QJyB3vtN4UfYwvmxdzOVM"
+      },
+      "power": "100",
+      "name": "",
+      "pro_tx_hash": "F3D506822A24E7E4BE318A6ED7371CC1E1527880A594FE04629F50A1618DB8E7"
+    }
+  ],
+  "threshold_public_key": {
+    "type": "tendermint/PubKeyBLS12381",
+    "value": "imxjukh5hRY91Mvm/sfhQp6iSnICyvKMMdhY5Sq6Ej0QJyB3vtN4UfYwvmxdzOVM"
+  },
   "quorum_type": "{{ platform_drive_validator_set_llmq_type }}",
-  "quorum_hash": null,
+  "quorum_hash": "0000000000000000000000000000000000000000",
   "app_hash": ""
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tenderdash since version 0.36 is using boostrap peers to connect to the network. Also new version of tenderdash expect default values for validators set and quotum hash in genesis file.

## What was done?
<!--- Describe your changes in detail -->
- Fixed genesis.json and config.toml generation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
The new config won't be compatible with previous versions of tenderdash

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
