### PR TITLE
feat: conditional core/platform elastic beats

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -98,6 +98,7 @@
       dashd_zmq: true
       tags:
         - dashd
+    - role: elastic-beats
 
 - hosts: miners
   become: true
@@ -105,6 +106,7 @@
     - role: dashd
       tags:
         - dashd
+    - role: elastic-beats
 
 # Setup core on seed nodes
 
@@ -117,6 +119,7 @@
       dashd_indexes: true
       tags:
         - dashd
+    - role: elastic-beats
 
 # Setup core on masternodes
 
@@ -138,6 +141,7 @@
       tags:
         - dashd
     - mn-sentinel
+    - elastic-beats
 
 # Generate first block on seed node
 # so that all nodes leave IBD mode (required for mining)

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -98,7 +98,7 @@
       dashd_zmq: true
       tags:
         - dashd
-    - role: elastic-beats
+    - elastic-beats
 
 - hosts: miners
   become: true
@@ -106,7 +106,7 @@
     - role: dashd
       tags:
         - dashd
-    - role: elastic-beats
+    - elastic-beats
 
 # Setup core on seed nodes
 
@@ -119,7 +119,7 @@
       dashd_indexes: true
       tags:
         - dashd
-    - role: elastic-beats
+    - elastic-beats
 
 # Setup core on masternodes
 

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -6,7 +6,7 @@
 - hosts: masternodes
   become: true
   roles:
-    -  remove-fake-latency
+    - remove-fake-latency
 
 - hosts: all
   gather_facts: true
@@ -72,7 +72,7 @@
       aws_scripts_mon_options: "--mem-util --disk-space-util --disk-path=/ --swap-util"
       aws_scripts_mon_use_iam: true
 
-# Configure dashd cli and network logging (if enanbled)
+# Configure dashd cli and network logging (if enabled)
 
 - hosts: all
   become: true

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -171,6 +171,7 @@
       dashd_zmq: true
       dashd_listen: true
     - insight
+    - elastic-beats
   tags:
     - web
 

--- a/ansible/roles/elastic-beats/tasks/main.yml
+++ b/ansible/roles/elastic-beats/tasks/main.yml
@@ -8,138 +8,22 @@
   command: docker ps -aqf "name=mn_evo_services_tendermint"
   register: tenderdash_container_id
 
+- include_vars:
+    file: common.yml
+
+- include_vars:
+    file: core.yml
+    name: beat_conf
+
+- include_vars:
+    file: platform.yml
+    name: platform_beat_conf
+  when: tenderdash_container_id.stdout != ""
+
+- set_fact:
+    beat_conf: "{{ [beat_conf, platform_beat_conf] | combine(recursive=True, list_merge='append') }}"
+  when: tenderdash_container_id.stdout != ""
+
 - name: set up filebeat log monitoring
   include_role:
     name: elastic.beats
-  vars:
-    beats_version: "{{ elastic_version }}"
-    beat: filebeat
-    beat_conf:
-      setup:
-        template:
-          enabled: false
-      filebeat:
-        inputs:
-          - type: container
-            enabled: true
-            index: "logs-core-{{ dash_network_name }}-%{[agent.version]}"
-            paths:
-              - '/var/lib/docker/containers/{{ core_container_id.stdout }}*/*.log'
-            processors:
-              - add_fields:
-                  target: event
-                  fields:
-                    dataset: "core-{{ dash_network_name }}"
-              - dissect:
-                  tokenizer: "%{?timestamp} %{message}"
-                  overwrite_keys: true
-                  target_prefix: ""
-          - type: log
-            enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
-            json.message_key: msg
-            json.keys_under_root: false
-            exclude_files: ['\.gz$']
-            index: "logs-drive.abci-{{ dash_network_name }}-%{[agent.version]}"
-            paths:
-              - "{{ mn_evo_services_path }}/logs/drive-json*.log*"
-            processors:
-              - timestamp:
-                  field: json.time
-                  layouts:
-                    - UNIX_MS
-              - if:
-                  equals:
-                    json.level: 10
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: trace
-              - if:
-                  equals:
-                    json.level: 20
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: debug
-              - if:
-                  equals:
-                    json.level: 30
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: info
-              - if:
-                  equals:
-                    json.level: 40
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: warn
-              - if:
-                  equals:
-                    json.level: 50
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: error
-              - if:
-                  equals:
-                    json.level: 60
-                then:
-                  - add_fields:
-                      target: log
-                      fields:
-                        level: fatal
-              - add_fields:
-                  target: event
-                  fields:
-                    dataset: "drive.abci-{{ dash_network_name }}"
-              - rename:
-                  fields:
-                    - from: "json.msg"
-                      to: "message"
-                  ignore_missing: true
-                  fail_on_error: true
-              - drop_fields:
-                  fields:
-                    - json.pid
-                    - json.hostname
-                    - json.time
-                  ignore_missing: true
-          - type: container
-            enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
-            json.message_key: _msg
-            json.keys_under_root: false
-            index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
-            paths:
-              - '/var/lib/docker/containers/{{ tenderdash_container_id.stdout }}*/*.log'
-            processors:
-              - add_fields:
-                  target: event
-                  fields:
-                    dataset: "drive.tenderdash-{{ dash_network_name }}"
-              - rename:
-                  fields:
-                    - from: "json._msg"
-                      to: "message"
-                  ignore_missing: true
-                  fail_on_error: true
-              - rename:
-                  fields:
-                    - from: "json.level"
-                    - to: "log.level"
-    output_conf:
-      elasticsearch:
-        hosts:
-          - "{{ hostvars['logs-1'].private_ip }}:9200"
-        username: "{{ elastic_username }}"
-        password: "{{ elastic_password }}"
-    logging_conf:
-      level: info
-      files:
-        rotateeverybytes: 10485760

--- a/ansible/roles/elastic-beats/vars/common.yml
+++ b/ansible/roles/elastic-beats/vars/common.yml
@@ -1,0 +1,14 @@
+---
+
+beats_version: "{{ elastic_version }}"
+beat: filebeat
+output_conf:
+  elasticsearch:
+    hosts:
+      - "{{ hostvars['logs-1'].private_ip }}:9200"
+    username: "{{ elastic_username }}"
+    password: "{{ elastic_password }}"
+logging_conf:
+  level: info
+  files:
+    rotateeverybytes: 10485760

--- a/ansible/roles/elastic-beats/vars/core.yml
+++ b/ansible/roles/elastic-beats/vars/core.yml
@@ -1,0 +1,21 @@
+---
+
+setup:
+template:
+  enabled: false
+filebeat:
+  inputs:
+    - type: container
+      enabled: true
+      index: "logs-core-{{ dash_network_name }}-%{[agent.version]}"
+      paths:
+        - '/var/lib/docker/containers/{{ core_container_id.stdout }}*/*.log'
+      processors:
+        - add_fields:
+            target: event
+            fields:
+              dataset: "core-{{ dash_network_name }}"
+        - dissect:
+            tokenizer: "%{?timestamp} %{message}"
+            overwrite_keys: true
+            target_prefix: ""

--- a/ansible/roles/elastic-beats/vars/platform.yml
+++ b/ansible/roles/elastic-beats/vars/platform.yml
@@ -1,0 +1,103 @@
+---
+
+filebeat:
+  inputs:
+    - type: log
+      enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
+      json.message_key: msg
+      json.keys_under_root: false
+      exclude_files: ['\.gz$']
+      index: "logs-drive.abci-{{ dash_network_name }}-%{[agent.version]}"
+      paths:
+        - "{{ mn_evo_services_path }}/logs/drive-json*.log*"
+      processors:
+        - timestamp:
+            field: json.time
+            layouts:
+              - UNIX_MS
+        - if:
+            equals:
+              json.level: 10
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: trace
+        - if:
+            equals:
+              json.level: 20
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: debug
+        - if:
+            equals:
+              json.level: 30
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: info
+        - if:
+            equals:
+              json.level: 40
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: warn
+        - if:
+            equals:
+              json.level: 50
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: error
+        - if:
+            equals:
+              json.level: 60
+          then:
+            - add_fields:
+                target: log
+                fields:
+                  level: fatal
+        - add_fields:
+            target: event
+            fields:
+              dataset: "drive.abci-{{ dash_network_name }}"
+        - rename:
+            fields:
+              - from: "json.msg"
+                to: "message"
+            ignore_missing: true
+            fail_on_error: true
+        - drop_fields:
+            fields:
+              - json.pid
+              - json.hostname
+              - json.time
+            ignore_missing: true
+    - type: container
+      enabled: "{{ tenderdash_container_id.stdout | length > 0 }}"
+      json.message_key: _msg
+      json.keys_under_root: false
+      index: "logs-drive.tenderdash-{{ dash_network_name }}-%{[agent.version]}"
+      paths:
+        - '/var/lib/docker/containers/{{ tenderdash_container_id.stdout }}*/*.log'
+      processors:
+        - add_fields:
+            target: event
+            fields:
+              dataset: "drive.tenderdash-{{ dash_network_name }}"
+        - rename:
+            fields:
+              - from: "json._msg"
+                to: "message"
+            ignore_missing: true
+            fail_on_error: true
+        - rename:
+            fields:
+              - from: "json.level"
+              - to: "log.level"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During recent core testing, it was common to recreate the core container without replaying the remainder of the playbook. Because `elastic-beats` was only set to run for platform deployment, this means that core logs were no longer captured if the platform deployment did not run.

## What was done?
<!--- Describe your changes in detail -->
This PR adds `elastic-beats` to core plays on all nodes, including miner, wallet and web nodes for the first time. Running core plays will now also update filebeat with new container IDs, and platform config is conditionally deployed on each run of the play, depending on whether platform is deployed or not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- On devnet-jack-daniels

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
@nmarley is this still idempotent? I'm not quite sure how to reason about deploying a single config to cover all three services at different times in the playbook.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
