### PR TITLE
fix: use local directory in case of multiple users

### DIFF
--- a/ansible/roles/elastic-stack/tasks/main.yml
+++ b/ansible/roles/elastic-stack/tasks/main.yml
@@ -24,12 +24,12 @@
   run_once: true
   fetch:
     src: '{{ bundle_path }}/bundle.zip'
-    dest: /tmp/ansible/{{ dash_network_name }}/
+    dest: ~/tmp/ansible/{{ dash_network_name }}/
     flat: true
 
 - name: install certs
   unarchive:
-    src: /tmp/ansible/{{ dash_network_name }}/bundle.zip
+    src: ~/tmp/ansible/{{ dash_network_name }}/bundle.zip
     dest: '{{ certs_path }}'
     include: [ '{{ inventory_hostname }}/*', 'ca/ca.crt' ]
 

--- a/ansible/roles/openvpn/tasks/main.yml
+++ b/ansible/roles/openvpn/tasks/main.yml
@@ -17,9 +17,10 @@
     openvpn_set_dns: false
     openvpn_push: "[ 'route-nopull' ] + {{openvpn_forwarded_ips}}"
     openvpn_redirect_gateway: no
+    openvpn_fetch_client_configs_dir: ~/tmp/ansible/
 
 - name: Copy OpenVPN config to 'networks' dir
   become: no
   vars:
-    openvpn_config_path: "/tmp/ansible/{{ dash_network_name }}/{{inventory_hostname}}.ovpn"
+    openvpn_config_path: "~/tmp/ansible/{{ dash_network_name }}/{{inventory_hostname}}.ovpn"
   local_action: "copy src={{ openvpn_config_path }} dest=../networks/{{ dash_network_name }}.ovpn"


### PR DESCRIPTION
For elastic-beats and vpn roles it will use the generic /tmp directory, this is an issue as these files are then "locked" by that user. In the case of using a manager node with multiple users the other users will then get "permission denied" when they attempt to do a deployment

## Issue being fixed or feature implemented
elastic-beats and vpn roles now use local directory in the user's home to generate certificates


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
Deployed a devnet


## Breaking Changes
If another user deploys over the top, it will regenerate a certificates. This shouldn't be too much of an issue AFAIK
