### PR TITLE
fix: drive tests fail against v0.23

### DIFF
--- a/test/smoke/drive.js
+++ b/test/smoke/drive.js
@@ -5,7 +5,7 @@ const getNetworkConfig = require('../../lib/test/getNetworkConfig');
 const { variables, inventory } = getNetworkConfig();
 
 async function sendEcho(ip) {
-  const echoRequestBytes = Buffer.from('0e12050a03010203', 'hex');
+  const echoRequestBytes = Buffer.from('0a0a080a0668656c6c6f21', 'hex');
 
   return new Promise((resolve, reject) => {
     const client = net.connect(26658, ip);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive tests were failing against devnet-jack-daniels

## What was done?
<!--- Describe your changes in detail -->
Update old magic string to new magic string provided by shumkov

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-jack-daniels

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Won't work with Drive <0.23

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
