### PR TITLE
fix: openvpn persists after SIGINT

### DIFF
--- a/lib/test/bootstrap.js
+++ b/lib/test/bootstrap.js
@@ -22,5 +22,9 @@ after(shutdownVpnClient);
 
 process.on('uncaughtException', console.error);
 process.on('unhandledRejection', console.error);
+process.on('SIGINT', () => {
+  shutdownVpnClient();
+  process.exit(1);
+});
 
 global.expect = expect;

--- a/lib/test/bootstrap.js
+++ b/lib/test/bootstrap.js
@@ -22,8 +22,8 @@ after(shutdownVpnClient);
 
 process.on('uncaughtException', console.error);
 process.on('unhandledRejection', console.error);
-process.on('SIGINT', () => {
-  shutdownVpnClient();
+process.on('SIGINT', async () => {
+  await shutdownVpnClient();
   process.exit(1);
 });
 

--- a/lib/test/bootstrap.js
+++ b/lib/test/bootstrap.js
@@ -22,9 +22,5 @@ after(shutdownVpnClient);
 
 process.on('uncaughtException', console.error);
 process.on('unhandledRejection', console.error);
-process.on('SIGINT', async () => {
-  await shutdownVpnClient();
-  process.exit(1);
-});
 
 global.expect = expect;

--- a/lib/test/openVpn.js
+++ b/lib/test/openVpn.js
@@ -42,16 +42,11 @@ async function shutdown() {
 
   // Close telnet connection to VPN client
   if (vpn) {
-    console.log('events are');
-    console.log(Object.keys(vpn._events));
     await new Promise((r) => setTimeout(r, 2000));
-    console.log('done waiting');
     vpn.on('disconnected', () => {
-      console.log('destroying after disconnect');
       vpnManager.destroy();
     });
   } else {
-    console.log('destroying without vpn.on');
     vpnManager.destroy();
   }
 }

--- a/lib/test/openVpn.js
+++ b/lib/test/openVpn.js
@@ -40,24 +40,12 @@ async function shutdown() {
   // Send SIGTERM to VPN Client
   vpnManager.disconnect();
 
-  function getPromiseFromEvent(item, event) {
-    return new Promise((resolve) => {
-      const listener = () => {
-        item.removeEventListener(event, listener);
-        resolve();
-      };
-      console.log('in promise thing');
-      item.addEventListener(event, listener);
-    });
-  }
-
   // Close telnet connection to VPN client
   if (vpn) {
     console.log('events are');
     console.log(Object.keys(vpn._events));
-    // await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, 2000));
     console.log('done waiting');
-    await getPromiseFromEvent(vpn, 'disconnected');
     vpn.on('disconnected', () => {
       console.log('destroying after disconnect');
       vpnManager.destroy();
@@ -71,7 +59,6 @@ async function shutdown() {
 // Prevent the hang of the Node process
 process.on('uncaughtException', shutdown);
 process.on('unhandledRejection', shutdown);
-process.on('exit', shutdown);
 
 module.exports = {
   waitForConnection,

--- a/lib/test/openVpn.js
+++ b/lib/test/openVpn.js
@@ -36,24 +36,33 @@ async function waitForConnection() {
   });
 }
 
-async function shutdown() {
-  // Send SIGTERM to VPN Client
-  vpnManager.disconnect();
+function shutdown() {
+  return new Promise((resolve) => {
+    // Send SIGTERM to VPN Client
+    vpnManager.disconnect();
 
-  // Close telnet connection to VPN client
-  if (vpn) {
-    await new Promise((r) => setTimeout(r, 2000));
-    vpn.on('disconnected', () => {
+    // Close telnet connection to VPN client
+    if (vpn) {
+      vpn.on('disconnected', () => {
+        vpnManager.destroy();
+        resolve();
+      });
+    } else {
       vpnManager.destroy();
-    });
-  } else {
-    vpnManager.destroy();
-  }
+      resolve();
+    }
+  });
 }
 
 // Prevent the hang of the Node process
 process.on('uncaughtException', shutdown);
 process.on('unhandledRejection', shutdown);
+
+process.on('SIGTERM', async () => {
+  vpnManager.destroy();
+
+  process.exit(0);
+});
 
 module.exports = {
   waitForConnection,

--- a/lib/test/openVpn.js
+++ b/lib/test/openVpn.js
@@ -36,16 +36,34 @@ async function waitForConnection() {
   });
 }
 
-function shutdown() {
+async function shutdown() {
   // Send SIGTERM to VPN Client
   vpnManager.disconnect();
 
+  function getPromiseFromEvent(item, event) {
+    return new Promise((resolve) => {
+      const listener = () => {
+        item.removeEventListener(event, listener);
+        resolve();
+      };
+      console.log('in promise thing');
+      item.addEventListener(event, listener);
+    });
+  }
+
   // Close telnet connection to VPN client
   if (vpn) {
+    console.log('events are');
+    console.log(Object.keys(vpn._events));
+    // await new Promise((r) => setTimeout(r, 1000));
+    console.log('done waiting');
+    await getPromiseFromEvent(vpn, 'disconnected');
     vpn.on('disconnected', () => {
+      console.log('destroying after disconnect');
       vpnManager.destroy();
     });
   } else {
+    console.log('destroying without vpn.on');
     vpnManager.destroy();
   }
 }

--- a/lib/test/openVpn.js
+++ b/lib/test/openVpn.js
@@ -36,33 +36,23 @@ async function waitForConnection() {
   });
 }
 
-function shutdown() {
-  return new Promise((resolve) => {
-    // Send SIGTERM to VPN Client
-    vpnManager.disconnect();
+async function shutdown() {
+  await vpnManager.disconnect();
+  vpnManager.destroy();
+}
 
-    // Close telnet connection to VPN client
-    if (vpn) {
-      vpn.on('disconnected', () => {
-        vpnManager.destroy();
-        resolve();
-      });
-    } else {
-      vpnManager.destroy();
-      resolve();
-    }
-  });
+async function handleTermSignal() {
+  await shutdown();
+
+  process.exit(0);
 }
 
 // Prevent the hang of the Node process
 process.on('uncaughtException', shutdown);
 process.on('unhandledRejection', shutdown);
 
-process.on('SIGTERM', async () => {
-  vpnManager.destroy();
-
-  process.exit(0);
-});
+process.on('SIGTERM', handleTermSignal);
+process.on('SIGINT', handleTermSignal);
 
 module.exports = {
   waitForConnection,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
OpenVPN remains connected after interrupting a smoke test run with Ctrl + C. Subsequent runs reuse the same VPN connection, meaning it is not possible to run smoke tests on a different network without first running `sudo kill $(pidof openvpn)`.

## What was done?
<!--- Describe your changes in detail -->
Catch `SIGINT` and give OpenVPN time to disconnect and destroy the client.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-jack-daniels`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
This changes the prior behaviour, but I consider it a fix of incorrect behaviour rather than a breaking change of behaviour

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
