### PR TITLE
fix: ansible.netcommon deprecation

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,17 +1,24 @@
-- src: geerlingguy.pip
-  version: 2.1.0
+---
 
-- src: geerlingguy.docker
-  version: 4.2.2
+collections:
+  - name: ansible.utils
+    version: 2.6.1
 
-- src: kyl191.openvpn
-  version: v0.9.1
-
-- src: Restless-ET.aws-scripts-mon
-  version: 1.0.1
-
-- src: arillso.logrotate
-  version: 1.6.1
-
-- src: elastic.beats
-  version: v7.17.0
+roles:
+  - src: geerlingguy.pip
+    version: 2.1.0
+  
+  - src: geerlingguy.docker
+    version: 4.2.2
+  
+  - src: kyl191.openvpn
+    version: v0.9.1
+  
+  - src: Restless-ET.aws-scripts-mon
+    version: 1.0.1
+  
+  - src: arillso.logrotate
+    version: 1.6.1
+  
+  - src: elastic.beats
+    version: v7.17.0

--- a/ansible/roles/dashd/defaults/main.yml
+++ b/ansible/roles/dashd/defaults/main.yml
@@ -10,10 +10,10 @@ dashd_externalip: '{{ public_ip }}'
 dashd_isseednode: '{{ dashd_externalip == dashd_seednode }}'
 
 dashd_private_net_prefix: 16
-dashd_private_cidr: '{{ private_ip|ipsubnet(dashd_private_net_prefix) }}'
+dashd_private_cidr: '{{ private_ip|ansible.utils.ipsubnet(dashd_private_net_prefix) }}'
 
 # When running devnet/regtest in local networks, we have to allow RFC1918/private addresses
-dashd_allowprivatenet: '{% if dashd_externalip|ipaddr("private") == dashd_externalip %}1{% else %}0{% endif %}'
+dashd_allowprivatenet: '{% if dashd_externalip|ansible.utils.ipaddr("private") == dashd_externalip %}1{% else %}0{% endif %}'
 
 dashd_compose_project_name: dashcore
 dashd_compose_path: '{{ dashd_home }}/{{ dashd_compose_project_name }}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
[DEPRECATION WARNING]: Use 'ansible.utils.ipsubnet' module instead. This feature will be 
removed from ansible.netcommon in a release after 2024-01-01. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
```

## What was done?
<!--- Describe your changes in detail -->
- Fix YML file syntax
- Add ansible.utils dependency and declare this namespace where used in roles

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On `devnet-filebeat`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
