### PR TITLE
fix: platform logs not rotated hourly

### DIFF
--- a/ansible/roles/mn-evo-services/tasks/main.yml
+++ b/ansible/roles/mn-evo-services/tasks/main.yml
@@ -16,7 +16,6 @@
   include_role:
     name: arillso.logrotate
   vars:
-    logrotate_use_hourly_rotation: true
     logrotate_applications:
       - name: platform-logs
         definitions:
@@ -32,10 +31,19 @@
               - compress
               - delaycompress
 
-- name: set mode to logrotate cron file
-  file:
-    path: /etc/cron.daily/logrotate
-    mode: "+x"
+- name: Ensure logrotate runs hourly under systemd timer
+  lineinfile:
+    path: /lib/systemd/system/logrotate.timer
+    regexp: '^OnCalendar=hourly'
+    insertafter: '^OnCalendar=daily'
+    line: OnCalendar=hourly
+
+- name: Enable and restart logrotate systemd timer
+  systemd:
+    name: logrotate.timer
+    state: restarted
+    enabled: yes
+    daemon_reload: true
 
 - name: copy files
   template:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Platform logs were not being rotated hourly because the version of logrotate shipping with ubuntu [disables](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858021) running from cron if systemd is installed.

## What was done?
<!--- Describe your changes in detail -->
Specify hourly logrotate using systemd

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-filebeat

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
