### PR TITLE
fix: logrotate doesn't use systemd on ubuntu bionic

### DIFF
--- a/ansible/roles/dashd/tasks/main.yml
+++ b/ansible/roles/dashd/tasks/main.yml
@@ -60,6 +60,7 @@
   include_role:
     name: arillso.logrotate
   vars:
+    logrotate_use_hourly_rotation: true
     logrotate_applications:
       - name: core-logs
         definitions:
@@ -75,19 +76,10 @@
               - compress
               - delaycompress
 
-- name: Ensure logrotate runs hourly under systemd timer
-  lineinfile:
-    path: /lib/systemd/system/logrotate.timer
-    regexp: '^OnCalendar=hourly'
-    insertafter: '^OnCalendar=daily'
-    line: OnCalendar=hourly
-
-- name: Enable and restart logrotate systemd timer
-  systemd:
-    name: logrotate.timer
-    state: restarted
-    enabled: yes
-    daemon_reload: true
+- name: set mode to logrotate cron file
+  file:
+    path: /etc/cron.daily/logrotate
+    mode: "+x"
 
 - name: Start dash core
   docker_compose:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
logrotate 3.11.x, which is installed on Ubuntu 18.04, does not create systemd timers in the same way as the version shipped by 22.04

## What was done?
<!--- Describe your changes in detail -->
Use cron to trigger logrotate hourly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We have already been using this approach in mn-evo-services

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
