### PR TITLE
tests: green tests after errors in mocha

### DIFF
--- a/lib/cli/test.sh
+++ b/lib/cli/test.sh
@@ -18,17 +18,16 @@ Please read README.md how to configure networks"
 
     openvpn_start
 
-    echo "Running mocha tests..."
-
+    trap 'RC=1' ERR
     set +e
 
+    echo "Running mocha tests..."
     test_run_mocha
 
-    set -e
-
     echo "Running karma tests..."
-
     test_run_karma
+
+    exit $RC
 }
 
 function test_run_mocha() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Smoke tests in CI were completing with green status if karma tests completed green, even if errors occurred in the mocha test run ([example](https://github.com/dashevo/dash-network-ci/actions/runs/3102113878/jobs/5024115496)). We need to run both mocha and karma tests each time, but exit with an error code if either tool exits with an error code.

## What was done?
<!--- Describe your changes in detail -->
Replace incomplete `set` logic with `trap`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Against testnet

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
