### PR TITLE
chore: move inventory update to separate step

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -183,6 +183,12 @@
   roles:
     - mn-init
 
+# Update inventory with protx values
+
+- hosts: masternode_wallet
+  roles:
+    - mn-protx-config
+
 # Activate sporks
 
 - hosts: masternode_wallet

--- a/ansible/roles/mn-init/tasks/main.yml
+++ b/ansible/roles/mn-init/tasks/main.yml
@@ -89,7 +89,3 @@
   vars:
     masternode_names: "{{ banned_masternode_names }}"
   when: banned_masternode_names|length > 0
-
-- name: update config with protx values
-  include_role:
-    name: mn-protx-config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Terraform frequently overwrites the inventory file, making it necessary to run the `mn-protx-config` role again. This was previously part of `mn-init`, meaning three files needed commenting to run just this role.

## What was done?
<!--- Describe your changes in detail -->
Move role out to separate step so it can be run separately with greater ease

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On devnet-jack-daniels

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
