### PR TITLE
fix: permission denied reading file on shared manager node

### DIFF
--- a/ansible/roles/elastic-stack/tasks/main.yml
+++ b/ansible/roles/elastic-stack/tasks/main.yml
@@ -20,6 +20,12 @@
   run_once: true
   delegate_to: '{{ play_hosts|first }}'
 
+- name: Create temp dir and set permissions
+  file:
+    path: /tmp/ansible/{{ dash_network_name }}
+    state: directory
+    mode: '0777'
+
 - name: fetch generated ca
   run_once: true
   fetch:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was not possible to re-deploy a network of the same name from the manager node if different users were doing the second deploy because the temp dir for storing certs was not writable by the other user.

## What was done?
<!--- Describe your changes in detail -->
Ensure temp dir is writable by all users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Untested, but this should totally work 🙈

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
